### PR TITLE
Prevent indefinite hangs when writing to the node monitoring UNIX socket

### DIFF
--- a/pkg/eventmon/logger/logger.go
+++ b/pkg/eventmon/logger/logger.go
@@ -83,7 +83,7 @@ func (l *LogProcessor) Send(entry *log.Entry) error {
 
 	// Set a write deadline in case we are writing to a connection, to avoid hangs
 	if conn, ok := l.Out.(net.Conn); ok {
-		conn.SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
+		conn.SetWriteDeadline(time.Now().Add(3 * time.Second))
 	}
 
 	if _, err = l.Out.Write(formatted); err != nil {

--- a/pkg/eventmon/logger/logger.go
+++ b/pkg/eventmon/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"io"
+	"net"
 	"runtime"
 	"time"
 
@@ -78,6 +79,11 @@ func (l *LogProcessor) Send(entry *log.Entry) error {
 	formatted, err := l.Formatter.Format(entry)
 	if err != nil {
 		return err
+	}
+
+	// Set a write deadline in case we are writing to a connection, to avoid hangs
+	if conn, ok := l.Out.(net.Conn); ok {
+		conn.SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
 	}
 
 	if _, err = l.Out.Write(formatted); err != nil {

--- a/pkg/eventmon/monitor/monitor.go
+++ b/pkg/eventmon/monitor/monitor.go
@@ -151,6 +151,7 @@ func (m *unixSupervisor) Reconnect() error {
 	if err != nil {
 		return err
 	}
+	go proc.Listen()
 	m.activeProc = true
 	m.processor = proc
 	m.attempts = 0

--- a/pkg/eventmon/monitor/monitor.go
+++ b/pkg/eventmon/monitor/monitor.go
@@ -178,7 +178,7 @@ func initLogProcessor(broker wire.EventBroker, uri *url.URL) (*logger.LogProcess
 	}
 
 	logProcessor := logger.New(broker, wc, nil)
-	go logProcessor.Launch()
+	go logProcessor.Listen()
 
 	return logProcessor, nil
 }

--- a/pkg/eventmon/monitor/monitor_test.go
+++ b/pkg/eventmon/monitor/monitor_test.go
@@ -152,6 +152,26 @@ func TestNotifyErrors(t *testing.T) {
 	wg.Wait()
 }
 
+// Test that we properly drop log entries instead of hanging when the buffer is full
+func TestHook(t *testing.T) {
+	// We do not need the msgChan, as we are simulating a frozen monitoring process
+	// Neither do we need the waitgroup, since waiting for this server to stop will
+	// block indefinitely.
+	_, _, _ = initTest()
+	eb := wire.NewEventBus()
+	supervisor, err := monitor.Launch(eb, unixSoc)
+	assert.NoError(t, err)
+
+	log.AddHook(supervisor)
+
+	// Log 1000 events
+	for i := 0; i < 1000; i++ {
+		log.Errorln("pippo")
+	}
+
+	_ = supervisor.Stop()
+}
+
 func mockBlockBuf(t *testing.T, height uint64) *bytes.Buffer {
 	blk := helper.RandomBlock(t, height, 4)
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
This commit should prevent a possible deadlock of the logrus instance, which can be caused if the node monitoring component hangs for any reason and does not read incoming messages. When this keeps going, the buffer can fill up and subsequent writes will block until this buffer is cleared.

Because we write to the node monitoring component with a logrus hook, the associated mutex is acquired and not released for as long as the write operation hangs.