### PR TITLE
Fix race condition in the agreement component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_script:
 
 script:
   - golint ./...
-  - go test -race -coverprofile=coverage.txt -covermode=atomic ./... # Run all the tests with the race detector enabled
+  - go test -p 1 -race -coverprofile=coverage.txt -covermode=atomic ./... # Run all the tests with the race detector enabled
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pkg/core/consensus/agreement/agreement_in_test.go
+++ b/pkg/core/consensus/agreement/agreement_in_test.go
@@ -1,0 +1,109 @@
+package agreement
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/committee"
+	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/reduction"
+	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/user"
+	"github.com/dusk-network/dusk-blockchain/pkg/core/database/lite"
+	"github.com/dusk-network/dusk-blockchain/pkg/core/tests/helper"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/peer/processing"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/encoding"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/protocol"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
+	crypto "github.com/dusk-network/dusk-crypto/hash"
+)
+
+func TestWrongCommittee(t *testing.T) {
+	// Sadly, we can not use the mocked committee for this test
+	// So, let's create one
+	eb := wire.NewEventBus()
+	_, db := lite.CreateDBConnection()
+	c := committee.NewAgreement(eb, db)
+	// We make a set of 50 keys, add these as provisioners and start the agreement component with key zero
+	committeeSize := 50
+	var k []user.Keys
+	for i := 0; i < committeeSize; i++ {
+		keys, _ := user.NewRandKeys()
+		buf := new(bytes.Buffer)
+		_ = encoding.Write256(buf, keys.EdPubKeyBytes)
+		_ = encoding.WriteVarBytes(buf, keys.BLSPubKeyBytes)
+		_ = encoding.WriteUint64(buf, binary.LittleEndian, 500)
+		_ = encoding.WriteUint64(buf, binary.LittleEndian, 0)
+		_ = encoding.WriteUint64(buf, binary.LittleEndian, 10000)
+		if err := c.AddProvisioner(buf); err != nil {
+			t.Fatal(err)
+		}
+		k = append(k, keys)
+	}
+
+	broker := newBroker(eb, c, k[0])
+	broker.updateRound(1)
+
+	eb.RegisterPreprocessor(string(topics.Gossip), processing.NewGossip(protocol.TestNet))
+	// We need to catch the outgoing agreement message
+	// Let's add a SimpleStreamer to the eventbus handlers
+	streamer := helper.NewSimpleStreamer()
+	eb.SubscribeStream(string(topics.Gossip), streamer)
+
+	// Increment the step counter on the agreement component
+	broker.state.IncrementStep()
+
+	// Let's now create a reduction vote set with the previous public keys
+	hash, _ := crypto.RandEntropy(32)
+
+	var events []wire.Event
+	for i := 1; i <= 2; i++ {
+		// We should only pick a certain key once, no dupes
+		picked := make(map[int]struct{})
+
+		// We do 38 votes per step, 75% of 50
+		for j := 0; j < 38; j++ {
+			// Key choices need to be randomized. There is no sorting in production
+			var n int
+			for {
+				n = rand.Intn(50)
+				if _, ok := picked[n]; !ok {
+					picked[n] = struct{}{}
+					break
+				}
+			}
+
+			ev := reduction.MockReduction(k[n], hash, 1, uint8(i))
+			events = append(events, ev)
+		}
+	}
+
+	aevBuf, err := broker.handler.createAgreement(events, broker.state.Round(), broker.state.Step())
+	eb.Stream(string(topics.Gossip), aevBuf)
+
+	aevBytes, err := streamer.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aevBuf = bytes.NewBuffer(aevBytes)
+
+	// Remove Ed25519 stuff first
+	// 64 for signature + 32 for pubkey = 96
+	edBytes := make([]byte, 96)
+	if _, err := aevBuf.Read(edBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	unmarshaller := NewUnMarshaller()
+	aev, err := unmarshaller.Deserialize(aevBuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, verify this event.
+	if err := broker.handler.Verify(aev); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/core/consensus/agreement/agreement_test.go
+++ b/pkg/core/consensus/agreement/agreement_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/reduction"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/user"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/tests/helper"
-	crypto "github.com/dusk-network/dusk-crypto/hash"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/peer/processing"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/encoding"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/protocol"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
+	crypto "github.com/dusk-network/dusk-crypto/hash"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/core/consensus/agreement/broker.go
+++ b/pkg/core/consensus/agreement/broker.go
@@ -24,6 +24,7 @@ func Launch(eventBroker wire.EventBroker, c committee.Foldable, keys user.Keys) 
 	broker := newBroker(eventBroker, c, keys)
 	currentRound := getInitialRound(eventBroker)
 	broker.updateRound(currentRound)
+	go broker.Listen()
 }
 
 type broker struct {

--- a/pkg/core/consensus/agreement/broker.go
+++ b/pkg/core/consensus/agreement/broker.go
@@ -61,8 +61,8 @@ func newBroker(eventBroker wire.EventBroker, committee committee.Foldable, keys 
 }
 
 // Listen for results coming from the accumulator and updating the round accordingly
-func (b *broker) Listen() {
-	evs := <-b.filter.Accumulator.CollectedVotesChan
+func (b *broker) Listen(votesChan <-chan []wire.Event) {
+	evs := <-votesChan
 	b.publishEvent(evs)
 	b.publishWinningHash(evs)
 	b.updateRound(b.state.Round() + 1)
@@ -110,7 +110,7 @@ func (b *broker) updateRound(round uint64) {
 	b.filter.UpdateRound(round)
 	consensus.UpdateRound(b.publisher, round)
 	b.filter.FlushQueue()
-	go b.Listen()
+	go b.Listen(b.filter.Accumulator.CollectedVotesChan)
 }
 
 func (b *broker) publishWinningHash(evs []wire.Event) {

--- a/pkg/core/consensus/agreement/collector.go
+++ b/pkg/core/consensus/agreement/collector.go
@@ -5,12 +5,24 @@ import (
 	"encoding/binary"
 
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/msg"
+	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/reduction"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/encoding"
 	log "github.com/sirupsen/logrus"
 )
 
 type initCollector struct {
 	initChannel chan uint64
+}
+
+type reductionResultCollector struct {
+	resultChan            chan voteSet
+	reductionUnmarshaller *reduction.UnMarshaller
+}
+
+type voteSet struct {
+	round uint64
+	votes []wire.Event
 }
 
 func (i *initCollector) Collect(roundBuffer *bytes.Buffer) error {
@@ -31,4 +43,26 @@ func getInitialRound(eventBus wire.EventBroker) uint64 {
 		"round":   round,
 	}).Debug("Received initial round")
 	return round
+}
+
+func initReductionResultCollector(subscriber wire.EventSubscriber) <-chan voteSet {
+	resultChan := make(chan voteSet, 1)
+	collector := &reductionResultCollector{resultChan, reduction.NewUnMarshaller()}
+	go wire.NewTopicListener(subscriber, collector, msg.ReductionResultTopic).Accept()
+	return resultChan
+}
+
+func (r *reductionResultCollector) Collect(m *bytes.Buffer) error {
+	var round uint64
+	if err := encoding.ReadUint64(m, binary.LittleEndian, &round); err != nil {
+		return err
+	}
+
+	votes, err := r.reductionUnmarshaller.UnmarshalVoteSet(m)
+	if err != nil {
+		return err
+	}
+
+	r.resultChan <- voteSet{round, votes}
+	return nil
 }


### PR DESCRIPTION
Fixes #62. The fix for the bug caused a slight API change for the agreement component (reduction results come in through a channel now) and thus the test to reproduce the bug was slightly changed as a result, to remain functional. To check the test before the update, and to run it for yourself, revert the branch to commit `14ac6da`, and it should fail. The only notable change should be the way the reduction result is sent.