### PR TITLE
Protocol methods refactoring.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	log "github.com/sirupsen/logrus"
-	"sync"
 
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/kadcast"
 	"github.com/dusk-network/dusk-blockchain/pkg/util/container/ring"
@@ -18,11 +17,9 @@ func main() {
 
 	// Create buffer.
 	queue := ring.NewBuffer(500)
-	// Create waitGroup
-	var wg sync.WaitGroup
 
 	// Launch PacketProcessor rutine.
-	go kadcast.ProcessPacket(queue, &router, &wg)
+	go kadcast.ProcessPacket(queue, &router)
 
 	// Launch a listener for our node.
 	go kadcast.StartUDPListener("udp", queue, router.MyPeerInfo)
@@ -35,13 +32,13 @@ func main() {
 	bootstrapNodes = append(bootstrapNodes[:], boot1)
 
 	// Start Bootstrapping process.
-	err := kadcast.InitBootstrap(&router, bootstrapNodes, &wg)
+	err := kadcast.InitBootstrap(&router, bootstrapNodes)
 	if err != nil {
 		log.Panic("Error during the Bootstrap Process. Job terminated.")
 	}
 
 	// Once the bootstrap succeeded, start the network discovery.
-	kadcast.StartNetworkDiscovery(&router, &wg)
+	kadcast.StartNetworkDiscovery(&router)
 
 	select {}
 }

--- a/pkg/p2p/kadcast/packet.go
+++ b/pkg/p2p/kadcast/packet.go
@@ -66,7 +66,7 @@ func (pac Packet) getHeadersInfo() (byte, [16]byte, [4]byte, [2]byte) {
 func (pac *Packet) setHeadersInfo(tipus byte, router Router, destPeer Peer) {
 	headers := make([]byte, 24)
 	// Add `Packet` type.
-	headers = append(headers[0:1], tipus)
+	headers[0] = tipus
 	// Add MyPeer ID
 	copy(headers[1:17], router.MyPeerInfo.id[0:16])
 	// Attach IdNonce

--- a/pkg/p2p/kadcast/packet.go
+++ b/pkg/p2p/kadcast/packet.go
@@ -186,16 +186,17 @@ func ProcessPacket(queue *ring.Buffer, router *Router, wg *sync.WaitGroup) {
 					"Source-IP", peerInf.ip[:],
 				).Infoln("Recieved PING message")
 				handlePing(peerInf, router)
-				// For NetwDisc we track the `PING` also since this is what
-				// introduces new `Peers` in the Buckets.
-				if isBootstrapping || isDiscoveringNetwork {
-					wg.Done()
-				}
 			case 1:
 				log.WithField(
 					"Source-IP", peerInf.ip[:],
 				).Infoln("Recieved PONG message")
 				handlePong(peerInf, router)
+				// For Bootstrapping and NetwDisc we track the 
+				// `PONG` messages since this is what
+				// introduces new `Peers` in the Buckets.
+				if isBootstrapping || isDiscoveringNetwork {
+					wg.Done()
+				}
 
 			case 2:
 				log.WithField(

--- a/pkg/p2p/kadcast/packet.go
+++ b/pkg/p2p/kadcast/packet.go
@@ -64,21 +64,21 @@ func (pac Packet) getHeadersInfo() (byte, [16]byte, [4]byte, [2]byte) {
 // Gets the Packet headers parts and puts them into the
 // header attribute of the Packet.
 func (pac *Packet) setHeadersInfo(tipus byte, router Router, destPeer Peer) {
-	var headers []byte
+	headers := make([]byte, 24)
 	// Add `Packet` type.
-	headers = append(headers[:], tipus)
+	headers = append(headers[0:1], tipus)
 	// Add MyPeer ID
-	headers = append(headers[:], router.MyPeerInfo.id[:]...)
+	copy(headers[1:17], router.MyPeerInfo.id[0:16])
 	// Attach IdNonce
 	idNonce := getBytesFromUint32(router.myPeerNonce)
-	headers = append(headers[:], idNonce[:]...)
+	copy(headers[17:21], idNonce[0:4])
 	// Attach Port
 	port := getBytesFromUint16(destPeer.port)
-	headers = append(headers[:], port[:]...)
+	copy(headers[21:23], port[0:2])
 
 	// Build headers array from the slice.
 	var headersArr [24]byte
-	copy(headersArr[:], headers[0:24])
+	copy(headersArr[:], headers[0:23])
 
 	pac.headers = headersArr
 }

--- a/pkg/p2p/kadcast/packet.go
+++ b/pkg/p2p/kadcast/packet.go
@@ -182,7 +182,9 @@ func ProcessPacket(queue *ring.Buffer, router *Router, wg *sync.WaitGroup) {
 			// Check packet type and process it.
 			switch tipus {
 			case 0:
-				log.Info("Recieved PING message from %v", peerInf.ip[:])
+				log.WithField(
+					"Source-IP", peerInf.ip[:],
+				).Infoln("Recieved PING message")
 				handlePing(peerInf, router)
 				// For NetwDisc we track the `PING` also since this is what
 				// introduces new `Peers` in the Buckets.
@@ -190,15 +192,21 @@ func ProcessPacket(queue *ring.Buffer, router *Router, wg *sync.WaitGroup) {
 					wg.Done()
 				}
 			case 1:
-				log.Info("Recieved PONG message from %v", peerInf.ip[:])
+				log.WithField(
+					"Source-IP", peerInf.ip[:],
+				).Infoln("Recieved PONG message")
 				handlePong(peerInf, router)
 
 			case 2:
-				log.Info("Recieved FIND_NODES message from %v", peerInf.ip[:])
+				log.WithField(
+					"Source-IP", peerInf.ip[:],
+				).Infoln("Recieved FIND_NODES message")
 				handleFindNodes(peerInf, router)
 
 			case 3:
-				log.Info("Recieved NODES message from %v", peerInf.ip[:])
+				log.WithField(
+					"Source-IP", peerInf.ip[:],
+				).Infoln("Recieved NODES message")
 				handleNodes(peerInf, packet, router, byteNum)
 			}
 		}
@@ -239,7 +247,7 @@ func handleNodes(peerInf Peer, packet Packet, router *Router, byteNum int) {
 	// peerNum announced <=> bytesPerPeer * peerNum
 	if !packet.checkNodesPayloadConsistency(byteNum) {
 		// Since the packet is not consisten, we just discard it.
-		log.Info("NODES message recieved with corrupted payload. PeerNum mismatch!\nIgnoring the packet.")
+		log.Info("NODES message recieved with corrupted payload. Packet ignored.")
 		return
 	}
 

--- a/pkg/p2p/kadcast/packet.go
+++ b/pkg/p2p/kadcast/packet.go
@@ -191,12 +191,6 @@ func ProcessPacket(queue *ring.Buffer, router *Router, wg *sync.WaitGroup) {
 					"Source-IP", peerInf.ip[:],
 				).Infoln("Recieved PONG message")
 				handlePong(peerInf, router)
-				// For Bootstrapping and NetwDisc we track the 
-				// `PONG` messages since this is what
-				// introduces new `Peers` in the Buckets.
-				if isBootstrapping || isDiscoveringNetwork {
-					wg.Done()
-				}
 
 			case 2:
 				log.WithField(

--- a/pkg/p2p/kadcast/peer.go
+++ b/pkg/p2p/kadcast/peer.go
@@ -68,12 +68,12 @@ func serializePeer(peerBytes []byte) Peer {
 func (peer Peer) computePeerNonce() uint32 {
 	var nonce uint32 = 0
 	var hash [32]byte
-	data := make([]byte, 18)
+	data := make([]byte, 20)
 	id := peer.id
 	for {
 		bytesUint := getBytesFromUint32(nonce)
 		copy(data[0:16], id[0:16])
-		copy(data[16:18], bytesUint[0:2])
+		copy(data[16:20], bytesUint[0:4])
 		hash = sha3.Sum256(data)
 		if (hash[31]) == 0 {
 			return nonce

--- a/pkg/p2p/kadcast/protocol.go
+++ b/pkg/p2p/kadcast/protocol.go
@@ -40,7 +40,7 @@ func InitBootstrap(router *Router, bootNodes []Peer, wg *sync.WaitGroup) error {
 				return errors.New("\nMaximum number of attempts achieved. Please review yor connection settings\n")
 			}
 			log.WithFields(log.Fields{
-				"Tries": i,
+				"Retries": i,
 			}).Warn("Bootstrapping nodes were not added.\nTrying again..")
 		} else {
 			isBootstrapping = false

--- a/pkg/p2p/kadcast/protocol.go
+++ b/pkg/p2p/kadcast/protocol.go
@@ -2,13 +2,11 @@ package kadcast
 
 import (
 	"errors"
+	"time"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
 )
-
-var isBootstrapping = false
-var isDiscoveringNetwork = false
 
 // InitBootstrap inits the Bootstrapping process by sending
 // a `PING` message to every bootstrapping node repeatedly.
@@ -17,33 +15,21 @@ var isDiscoveringNetwork = false
 // Otherways, it returns `nil` and logs the Number of peers
 // the node is connected to at the end of the process.
 func InitBootstrap(router *Router, bootNodes []Peer, wg *sync.WaitGroup) error {
-	isBootstrapping = true
 	log.Info("Bootstrapping process started.")
 	// Get PeerList ordered by distance so we can compare it
 	// after the `PONG` arrivals.
 	initPeerNum := router.tree.getTotalPeers()
 	for i := 0; i <= 3; i++ {
-		// Send `PING` to the bootstrap nodes.
-		for _, peer := range bootNodes {
-			router.sendPing(peer)
-		}
-		// Wait for `PONG` responses.
-		// With one of them we have enough.
-		wg.Add(1)
-		wg.Wait()
-		// If new peers were added (the bootstrap nodes)
-		// we consider that the bootstrapping succeeded.
-		actualPeers := router.tree.getTotalPeers()
+		
+		actualPeers := router.pollBootstrappingNodes(bootNodes, time.Second * 3)
 		if actualPeers <= initPeerNum {
 			if i == 3 {
-				isBootstrapping = false
 				return errors.New("\nMaximum number of attempts achieved. Please review yor connection settings\n")
 			}
 			log.WithFields(log.Fields{
 				"Retries": i,
 			}).Warn("Bootstrapping nodes were not added.\nTrying again..")
 		} else {
-			isBootstrapping = false
 			break
 		}
 	}
@@ -63,29 +49,22 @@ func InitBootstrap(router *Router, bootNodes []Peer, wg *sync.WaitGroup) error {
 // Otherways, if the closest Peer on two consecutive iterations changes, we
 // keep queriyng the `alpha` closest nodes with `FIND_NODES` messages.
 func StartNetworkDiscovery(router *Router, wg *sync.WaitGroup) {
-	isDiscoveringNetwork = true
-	var actualClosest []Peer
-	previousClosest := router.getXClosestPeersTo(1, router.MyPeerInfo)
-	// Ask for nodes to `alpha` closest nodes to my peer.
-	router.sendFindNodes()
-	// Wait until response arrives and we query the nodes.
-	wg.Add(1)
-	wg.Wait()
-	for {
-		actualClosest = router.getXClosestPeersTo(1, router.MyPeerInfo)
-		if actualClosest[0] == previousClosest[0] {
-			log.WithField(
-				"connected_peers", router.tree.getTotalPeers(),
-			).Info("Network Discovery process has finished!")
-			isDiscoveringNetwork = false
-			return
-		}
-		// We get the closest actual Peer.
-		previousClosest = actualClosest
-		// Send `FIND_NODES` again.
-		router.sendFindNodes()
-		// Wait until response arrives and we query the nodes.
-		wg.Add(1)
-		wg.Wait()
+	// Get closest actual Peer.
+	previousClosestArr := router.getXClosestPeersTo(1, router.MyPeerInfo)
+	previousClosest := previousClosestArr[0]
+
+	// Ask for new peers, wait for `PONG` arrivals and get the 
+	// new closest `Peer`.
+	actualClosest := router.pollClosestPeer(5 * time.Second)
+
+	// Until we don't get a peer closer to our node on each poll,
+	// we look for more nodes.
+	for actualClosest != previousClosest {
+		previousClosest	= actualClosest
+		actualClosest = router.pollClosestPeer(10 * time.Second)
 	}
+
+	log.WithFields(log.Fields{
+		"peers_connected": router.tree.getTotalPeers(),
+	}).Info("Network Discovery process finished.")
 }

--- a/pkg/p2p/kadcast/protocol.go
+++ b/pkg/p2p/kadcast/protocol.go
@@ -74,7 +74,9 @@ func StartNetworkDiscovery(router *Router, wg *sync.WaitGroup) {
 	for {
 		actualClosest = router.getXClosestPeersTo(1, router.MyPeerInfo)
 		if actualClosest[0] == previousClosest[0] {
-			log.Info("Network Discovery process has finished!.\nYou're now connected to %v", router.tree.getTotalPeers())
+			log.WithField(
+				"connected_peers", router.tree.getTotalPeers(),
+			).Info("Network Discovery process has finished!")
 			isDiscoveringNetwork = false
 			return
 		}

--- a/pkg/p2p/kadcast/protocol.go
+++ b/pkg/p2p/kadcast/protocol.go
@@ -20,7 +20,7 @@ func InitBootstrap(router *Router, bootNodes []Peer) error {
 	initPeerNum := router.tree.getTotalPeers()
 	for i := 0; i <= 3; i++ {
 
-		actualPeers := router.pollBootstrappingNodes(bootNodes, time.Second*3)
+		actualPeers := router.pollBootstrappingNodes(bootNodes, time.Second*5)
 		if actualPeers <= initPeerNum {
 			if i == 3 {
 				return errors.New("\nMaximum number of attempts achieved. Please review yor connection settings\n")
@@ -60,7 +60,7 @@ func StartNetworkDiscovery(router *Router) {
 	// we look for more nodes.
 	for actualClosest != previousClosest {
 		previousClosest = actualClosest
-		actualClosest = router.pollClosestPeer(10 * time.Second)
+		actualClosest = router.pollClosestPeer(5 * time.Second)
 	}
 
 	log.WithFields(log.Fields{

--- a/pkg/p2p/kadcast/router.go
+++ b/pkg/p2p/kadcast/router.go
@@ -8,6 +8,7 @@ import (
 // K is the number of peers that a node will send on
 // a `NODES` message.
 const K int = 20
+
 // Alpha is the number of nodes to which a node will
 // ask for new nodes with `FIND_NODES` messages.
 const Alpha int = 3
@@ -45,7 +46,6 @@ func MakeRouter(externIP [4]byte, port uint16) Router {
 // PeerID in terms of XOR-distance.				     //
 //													 //
 // --------------------------------------------------//
-
 
 // Returns the complete list of Peers in order to be sorted
 // as they have the xor distance in respec to a Peer as a parameter.
@@ -109,29 +109,29 @@ func (router Router) getXClosestPeersTo(peerNum int, refPeer Peer) []Peer {
 // ------- Packet-sending utilities for the Router ------- //
 
 // Builds and sends a `PING` packet
-func (router Router) sendPing(reciever Peer) {
+func (router Router) sendPing(receiver Peer) {
 	// Build empty packet.
 	var packet Packet
 	// Fill the headers with the type, ID, Nonce and destPort.
-	packet.setHeadersInfo(0, router, reciever)
+	packet.setHeadersInfo(0, router, receiver)
 
 	// Since return values from functions are not addressable, we need to
-	// allocate the reciever UDPAddr
-	destUDPAddr := reciever.getUDPAddr()
+	// allocate the receiver UDPAddr
+	destUDPAddr := receiver.getUDPAddr()
 	// Send the packet
 	sendUDPPacket("udp", destUDPAddr, packet.asBytes())
 }
 
 // Builds and sends a `PONG` packet
-func (router Router) sendPong(reciever Peer) {
+func (router Router) sendPong(receiver Peer) {
 	// Build empty packet.
 	var packet Packet
 	// Fill the headers with the type, ID, Nonce and destPort.
-	packet.setHeadersInfo(1, router, reciever)
+	packet.setHeadersInfo(1, router, receiver)
 
 	// Since return values from functions are not addressable, we need to
-	// allocate the reciever UDPAddr
-	destUDPAddr := reciever.getUDPAddr()
+	// allocate the receiver UDPAddr
+	destUDPAddr := receiver.getUDPAddr()
 	// Send the packet
 	sendUDPPacket("udp", destUDPAddr, packet.asBytes())
 }
@@ -153,17 +153,17 @@ func (router Router) sendFindNodes() {
 }
 
 // Builds and sends a `NODES` packet.
-func (router Router) sendNodes(reciever Peer) {
+func (router Router) sendNodes(receiver Peer) {
 	// Build empty packet
 	var packet Packet
 	// Set headers
-	packet.setHeadersInfo(3, router, reciever)
-	// Set payload with the `k` peers closest to reciever.
-	peersToSend := packet.setNodesPayload(router, reciever)
+	packet.setHeadersInfo(3, router, receiver)
+	// Set payload with the `k` peers closest to receiver.
+	peersToSend := packet.setNodesPayload(router, receiver)
 	// If we don't have any peers to announce, we just skip sending
 	// the `NODES` messsage.
 	if peersToSend == 0 {
 		return
 	}
-	sendUDPPacket("udp", reciever.getUDPAddr(), packet.asBytes())
+	sendUDPPacket("udp", receiver.getUDPAddr(), packet.asBytes())
 }

--- a/pkg/p2p/kadcast/utils.go
+++ b/pkg/p2p/kadcast/utils.go
@@ -71,7 +71,7 @@ func xorIsBigger(a [16]byte, b [16]byte) bool {
 func computePeerID(externIP [4]byte) [16]byte {
 	var halfLenID [16]byte
 	doubleLenID := sha3.Sum256(externIP[:])
-	copy(halfLenID[:], doubleLenID[0:15])
+	copy(halfLenID[:], doubleLenID[0:16])
 	return halfLenID
 }
 


### PR DESCRIPTION
The issue comes out from #141  and closes #180 

The protocol methods for the node have been refactored.

- Created polling methods for bootstrapping nodes and network discovery nodes.
- Refactored logger messages.
- Moved the logic away from the `protocol.go` methods and send it to the `router.go` polling methods. Which are blocking and await for the responses to `PING` and `FIND_NODES` messages.