### PR TITLE
Remove EventBus busLock

### DIFF
--- a/pkg/util/nativeutils/eventbus/eventbus.go
+++ b/pkg/util/nativeutils/eventbus/eventbus.go
@@ -1,7 +1,6 @@
 package eventbus
 
 import (
-	"sync"
 	"time"
 
 	lg "github.com/sirupsen/logrus"
@@ -23,7 +22,6 @@ type (
 
 	// EventBus - box for listeners and callbacks.
 	EventBus struct {
-		busLock         sync.RWMutex
 		listeners       *listenerMap
 		defaultListener *multiListener
 	}
@@ -32,7 +30,6 @@ type (
 // New returns new EventBus with empty listeners.
 func New() *EventBus {
 	return &EventBus{
-		busLock:         sync.RWMutex{},
 		listeners:       newListenerMap(),
 		defaultListener: newMultiListener(),
 	}

--- a/pkg/util/nativeutils/eventbus/subscriber.go
+++ b/pkg/util/nativeutils/eventbus/subscriber.go
@@ -13,8 +13,6 @@ type Subscriber interface {
 
 // Subscribe subscribes to a topic with a channel.
 func (bus *EventBus) Subscribe(topic topics.Topic, listener Listener) uint32 {
-	bus.busLock.Lock()
-	defer bus.busLock.Unlock()
 	return bus.listeners.Store(topic, listener)
 }
 


### PR DESCRIPTION
nitpick: `listenerMap` is concurrent-safe so busLock mutex looks redundant.