### PR TITLE
Return an empty slice when transaction is not found on a GetMempoolTxs request

### DIFF
--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -383,7 +383,7 @@ func (m Mempool) processGetMempoolTxsRequest(r rpcbus.Request) (interface{}, err
 	if len(filterTxID) == 32 {
 		tx := m.verified.Get(filterTxID)
 		if tx == nil {
-			return nil, errors.New("tx not found")
+			return outputTxs, nil
 		}
 
 		outputTxs = append(outputTxs, tx)


### PR DESCRIPTION
Fixes #333 