### PR TITLE
Respond with node.TxHistoryResponse instead of bytes.Buffer

### DIFF
--- a/harness/engine/node.go
+++ b/harness/engine/node.go
@@ -27,6 +27,7 @@ func NewDuskNode(graphqlPort, nodeId int, profileID string) *DuskNode {
 
 	node.Cfg = config.Registry{}
 	node.Cfg.Gql.Address = "127.0.0.1:" + strconv.Itoa(graphqlPort)
+	node.Cfg.Gql.Network = "tcp"
 
 	if *RPCNetworkType == "unix" {
 		node.Cfg.RPC.Network = "unix"

--- a/harness/engine/profiles.go
+++ b/harness/engine/profiles.go
@@ -20,6 +20,7 @@ func Profile1(index int, node *DuskNode, walletPath string) {
 
 	viper.Set("logger.output", node.Dir+"/dusk")
 	viper.Set("gql.address", node.Cfg.Gql.Address)
+	viper.Set("gql.network", node.Cfg.Gql.Network)
 	viper.Set("gql.enabled", "true")
 
 	viper.Set("rpc.network", node.Cfg.RPC.Network)

--- a/pkg/core/transactor/listener.go
+++ b/pkg/core/transactor/listener.go
@@ -131,11 +131,6 @@ func (t *Transactor) handleGetTxHistory(r rpcbus.Request) error {
 		return err
 	}
 
-	if len(records) == 0 {
-		r.RespChan <- rpcbus.Response{*bytes.NewBufferString("No records found."), nil}
-		return nil
-	}
-
 	resp := &node.TxHistoryResponse{Records: make([]*node.TxRecord, len(records))}
 	for i, record := range records {
 		resp.Records[i] = &node.TxRecord{


### PR DESCRIPTION
Found on wallet-cli testing after creating new wallet:
```
INFO[0530] Handled GetTxHistory request                  prefix=transactor
panic: interface conversion: interface {} is bytes.Buffer, not *node.TxHistoryResponse

```