### PR TITLE
Save/Retrieve PublicKey and ViewKey from .dat file in the Wallet#471

### DIFF
--- a/pkg/config/groups.go
+++ b/pkg/config/groups.go
@@ -44,9 +44,8 @@ type databaseConfiguration struct {
 
 // wallet configs
 type walletConfiguration struct {
-	File          string
-	SecretKeyFile string
-	Store         string
+	File  string
+	Store string
 }
 
 // pprof configs

--- a/pkg/core/data/transactions/provider.go
+++ b/pkg/core/data/transactions/provider.go
@@ -356,8 +356,6 @@ type keymaster struct {
 }
 
 // GenerateSecretKey creates a SecretKey using a []byte as Seed
-// TODO: shouldn't this also return the PublicKey and the ViewKey to spare
-// a roundtrip?
 func (k *keymaster) GenerateSecretKey(ctx context.Context, seed []byte) (SecretKey, PublicKey, ViewKey, error) {
 	sk := new(SecretKey)
 	pk := new(PublicKey)

--- a/pkg/core/data/wallet/wallet_test.go
+++ b/pkg/core/data/wallet/wallet_test.go
@@ -73,16 +73,16 @@ func TestNewWallet(t *testing.T) {
 	assert.NotNil(sk.A.Data)
 	assert.NotNil(sk.B.Data)
 
-	w, err := New(nil, seed, netPrefix, db, "pass", seedFile, secretFile, sk)
+	w, err := New(nil, seed, netPrefix, db, "pass", seedFile, sk)
 	assert.NoError(err)
 
 	// wrong wallet password
-	loadedWallet, err := LoadFromFile(netPrefix, db, "wrongPass", seedFile, secretFile)
+	loadedWallet, err := LoadFromFile(netPrefix, db, "wrongPass", seedFile)
 	assert.NotNil(err)
 	assert.Nil(loadedWallet)
 
 	// correct wallet password
-	loadedWallet, err = LoadFromFile(netPrefix, db, "pass", seedFile, secretFile)
+	loadedWallet, err = LoadFromFile(netPrefix, db, "pass", seedFile)
 	assert.Nil(err)
 
 	assert.Equal(w.SecretKey.A.Data, loadedWallet.SecretKey.A.Data)
@@ -116,7 +116,7 @@ func TestCatchEOF(t *testing.T) {
 		transactions.USecretKey(secretKey.Sk, sk)
 		require.Nil(t, err)
 
-		_, err = New(nil, seed, netPrefix, db, "pass", seedFile, secretFile, sk)
+		_, err = New(nil, seed, netPrefix, db, "pass", seedFile, sk)
 		assert.Nil(t, err)
 		os.Remove(seedFile)
 		os.Remove(secretFile)

--- a/pkg/core/transactor/listener.go
+++ b/pkg/core/transactor/listener.go
@@ -28,19 +28,8 @@ func (t *Transactor) handleCreateWallet(req *node.CreateRequest) (*node.LoadResp
 		return nil, errors.New("seed must be at least 64 bytes in size")
 	}
 
-	//generate secret key with rusk
-	// TODO: use parent context
-	ctx := context.Background()
-	sk, pb, vk, err := t.keyMaster.GenerateSecretKey(ctx, req.Seed)
-	if err != nil {
-		return nil, err
-	}
-
-	//set it for further use
-	t.secretKey = sk
-
 	//create wallet with seed and pass
-	err = t.loadWalletFromSeedPbAndVk(req.Seed, req.Password, pb, vk)
+	err := t.createWallet(req.Seed, req.Password)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +37,7 @@ func (t *Transactor) handleCreateWallet(req *node.CreateRequest) (*node.LoadResp
 	// TODO: will this still make sense after the migration
 	// t.launchConsensus()
 
-	return loadResponseFromPub(pb), nil
+	return loadResponseFromPub(t.w.PublicKey), nil
 }
 
 func (t *Transactor) handleAddress() (*node.LoadResponse, error) {
@@ -94,7 +83,7 @@ func (t *Transactor) handleLoadWallet(req *node.LoadRequest) (*node.LoadResponse
 		return nil, errWalletAlreadyLoaded
 	}
 
-	pubKey, _, err := t.loadWalletFromPasswordAndLoadPkVk(req.Password)
+	pubKey, err := t.loadWallet(req.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/core/transactor/listener.go
+++ b/pkg/core/transactor/listener.go
@@ -22,12 +22,6 @@ var (
 	errWalletAlreadyLoaded = errors.New("wallet is already loaded") //nolint
 )
 
-//nolint
-func loadResponse(pubKey []byte) *node.LoadResponse {
-	pk := &node.PubKey{PublicKey: pubKey}
-	return &node.LoadResponse{Key: pk}
-}
-
 func (t *Transactor) handleCreateWallet(req *node.CreateRequest) (*node.LoadResponse, error) {
 	//return err if user sends no seed
 	if len(req.Seed) < 64 {
@@ -37,9 +31,7 @@ func (t *Transactor) handleCreateWallet(req *node.CreateRequest) (*node.LoadResp
 	//generate secret key with rusk
 	// TODO: use parent context
 	ctx := context.Background()
-	// QUESTION: since GenerateSecretKey also returns a PublicKey and a
-	// ViewKey, does it still make sense to call `createFromSeed` later on?
-	sk, _, _, err := t.keyMaster.GenerateSecretKey(ctx, req.Seed)
+	sk, pb, vk, err := t.keyMaster.GenerateSecretKey(ctx, req.Seed)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +40,7 @@ func (t *Transactor) handleCreateWallet(req *node.CreateRequest) (*node.LoadResp
 	t.secretKey = sk
 
 	//create wallet with seed and pass
-	pubKey, _, err := t.createFromSeed(req.Seed, req.Password)
+	err = t.loadWalletFromSeedPbAndVk(req.Seed, req.Password, pb, vk)
 	if err != nil {
 		return nil, err
 	}
@@ -56,9 +48,7 @@ func (t *Transactor) handleCreateWallet(req *node.CreateRequest) (*node.LoadResp
 	// TODO: will this still make sense after the migration
 	// t.launchConsensus()
 
-	return &node.LoadResponse{Key: &node.PubKey{
-		PublicKey: pubKey.ToAddr(),
-	}}, nil
+	return loadResponseFromPub(pb), nil
 }
 
 func (t *Transactor) handleAddress() (*node.LoadResponse, error) {
@@ -67,9 +57,7 @@ func (t *Transactor) handleAddress() (*node.LoadResponse, error) {
 		return nil, errors.New("SecretKey is not set")
 	}
 
-	return &node.LoadResponse{Key: &node.PubKey{
-		PublicKey: t.w.PublicKey.ToAddr(),
-	}}, nil
+	return loadResponseFromPub(t.w.PublicKey), nil
 }
 
 func (t *Transactor) handleGetTxHistory() (*node.TxHistoryResponse, error) {
@@ -102,30 +90,25 @@ func (t *Transactor) handleGetTxHistory() (*node.TxHistoryResponse, error) {
 }
 
 func (t *Transactor) handleLoadWallet(req *node.LoadRequest) (*node.LoadResponse, error) {
-	// TODO: will this still make sense after migration?
-	// if t.w != nil {
-	// 	return nil, errWalletAlreadyLoaded
-	// }
+	if t.w != nil {
+		return nil, errWalletAlreadyLoaded
+	}
 
-	pubKey, _, err := t.loadWallet(req.Password)
+	pubKey, _, err := t.loadWalletFromPasswordAndLoadPkVk(req.Password)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO: will this still make sense after migration?
 	// t.launchConsensus()
-	// return loadResponse([]byte(pubKey)), nil
 
-	return &node.LoadResponse{Key: &node.PubKey{
-		PublicKey: pubKey.ToAddr(),
-	}}, nil
+	return loadResponseFromPub(pubKey), nil
 }
 
 func (t *Transactor) handleCreateFromSeed(req *node.CreateRequest) (*node.LoadResponse, error) {
-	// TODO: will this still make sense after migration?
-	// if t.w != nil {
-	// 	return nil, errWalletAlreadyLoaded
-	// }
+	if t.w != nil {
+		return nil, errWalletAlreadyLoaded
+	}
 
 	ctx := context.Background()
 	records, err := t.walletClient.CreateFromSeed(ctx, &node.CreateRequest{Password: req.Password, Seed: req.Seed})
@@ -135,7 +118,7 @@ func (t *Transactor) handleCreateFromSeed(req *node.CreateRequest) (*node.LoadRe
 
 	// TODO: will this still make sense after migration?
 	// t.launchConsensus()
-	// return loadResponse([]byte(pubKey)), nil
+
 	return records, nil
 }
 
@@ -304,6 +287,11 @@ func (t *Transactor) handleSendContract(c *node.CallContractRequest) (*node.Tran
 	}
 
 	return &node.TransactionResponse{Hash: hash}, nil
+}
+
+func loadResponseFromPub(pubKey transactions.PublicKey) *node.LoadResponse {
+	pk := &node.PubKey{PublicKey: pubKey.ToAddr()}
+	return &node.LoadResponse{Key: pk}
 }
 
 //nolint:unused


### PR DESCRIPTION
* Updated createFromSeed to loadWalletFromSeedPbAndVk and added pk transactions.PublicKey, vk transactions.ViewKey as arguments to avoid double round trip

* Save PublicKey and ViewKey inside loadWalletFromSeedPbAndVk after successfully calling  LoadFromSeed

* Update loadWallet to loadWalletFromPasswordAndLoadPkVk and save PublicKey and ViewKey into Wallet instance for further use

* Removed some code dups by reusing loadResponse func and updated its name to loadResponseFromPub

* Make use of arguments PublicKey and ViewKey returned by GenerateSecretKey into loadWalletFromSeedPbAndVk
