### PR TITLE
Add utils CMD to cmd/utils to generate transactions #547 

### DIFF
--- a/cmd/utils/transactions/transactions.go
+++ b/cmd/utils/transactions/transactions.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Transaction is the struct that holds common transaction fields
 type Transaction struct {
 	Amount   uint64
 	LockTime uint64

--- a/cmd/utils/transactions/transactions.go
+++ b/cmd/utils/transactions/transactions.go
@@ -1,0 +1,60 @@
+package transactions
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	pb "github.com/dusk-network/dusk-protobuf/autogen/go/node"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+type Transaction struct {
+	Amount   uint64
+	LockTime uint64
+	TXtype   string
+	Address  string
+}
+
+// RunTransactions will
+func RunTransactions(grpcHost string, transaction Transaction) (*pb.TransferResponse, error) {
+
+	log.WithField("transaction", transaction).Info("Set up a connection to the grpc server")
+	conn, err := grpc.Dial(grpcHost, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	client := pb.NewNodeClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var resp *pb.TransferResponse
+	switch transaction.TXtype {
+	case "consensus":
+		log.WithField("transaction", transaction).Info("Sending consensus tx")
+		req := pb.ConsensusTxRequest{Amount: transaction.Amount, LockTime: transaction.LockTime}
+		resp, err = client.SendBid(ctx, &req)
+	case "stake":
+		log.WithField("transaction", transaction).Info("Sending stake tx")
+		req := pb.ConsensusTxRequest{Amount: transaction.Amount, LockTime: transaction.LockTime}
+		resp, err = client.SendStake(ctx, &req)
+	case "transfer":
+		log.WithField("transaction", transaction).Info("Sending transfer tx")
+		req := pb.TransferRequest{Amount: transaction.Amount, Address: []byte(transaction.Address)}
+		resp, err = client.Transfer(ctx, &req)
+	default:
+		log.Info("")
+		err = errors.New("invalid TXtype")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
## Introduction:
In order to monitor the Dusk blockchain transactions, we need to have a utils cmd that creates all sort of transactions

## How to test:
Start a Dusk node using test harness with keepalive flag enabled:

```
NETWORK_SIZE=3 DUSK_BLOCKCHAIN=${PWD}/bin/dusk DUSK_BLINDBID=${PWD}/bin/blindbid-linux-amd64 DUSK_SEEDER=${PWD}/bin/voucher DUSK_WALLET_PASS="password" go test -v --count=1 --test.timeout=0 ./harness/tests/... -args -enable -keepalive
```

## Build and run transaction cmd
```
make build && ./bin/utils transactions --txtype=consensus --amount=10 --locktime=10 --grpchost=unix:///tmp/localnet-560157350/node-9001/dusk-grpc.sock
```
