### PR TITLE
add configpath argument to the wallet cmd

### DIFF
--- a/cmd/wallet/conf/config.go
+++ b/cmd/wallet/conf/config.go
@@ -33,10 +33,14 @@ type rpcConfiguration struct {
 }
 
 // InitConfig will init the config vars from viper
-func InitConfig() Registry {
+func InitConfig(cfg string) Registry {
 	viper.SetConfigName("dusk")
-	viper.AddConfigPath(".")
-	viper.AddConfigPath("$HOME/.dusk/")
+	if cfg == "" {
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("$HOME/.dusk/")
+	} else {
+		viper.AddConfigPath(cfg)
+	}
 
 	if err := viper.ReadInConfig(); err != nil {
 		_, _ = fmt.Fprintln(os.Stdout, "Config file not found. Please place dusk-wallet-cli in the same directory as your dusk.toml file.")

--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -6,16 +6,41 @@ import (
 	"os"
 	"time"
 
+	"github.com/urfave/cli"
+
 	"github.com/dusk-network/dusk-blockchain/cmd/wallet/conf"
 	"github.com/dusk-network/dusk-blockchain/cmd/wallet/prompt"
 
 	"github.com/dusk-network/dusk-protobuf/autogen/go/node"
 )
 
+var (
+	configPathFlag = cli.StringFlag{
+		Name:  "configpath",
+		Usage: "dusk toml path , eg: --configpath=/tmp/localnet-317173610/node-9000",
+		Value: "",
+	}
+)
+
 func main() {
+	app := cli.NewApp()
+	app.Usage = "The Dusk Wallet command line interface"
+	app.Action = walletAction
+	app.Flags = []cli.Flag{
+		configPathFlag,
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func walletAction(ctx *cli.Context) error {
 	defer handlePanic()
 
-	config := conf.InitConfig()
+	configPath := ctx.String(configPathFlag.Name)
+	config := conf.InitConfig(configPath)
 
 	// Establish a gRPC connection with the node.
 	_, _ = fmt.Fprintln(os.Stdout, "Wallet will establish a gRPC connection with the node.", config.RPC.Address)
@@ -23,7 +48,7 @@ func main() {
 
 	if err := client.Connect(config.RPC); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
 	// TODO: deferred functions are not run when os.Exit is called
 	defer client.Close()
@@ -32,7 +57,7 @@ func main() {
 	resp, err := client.NodeClient.GetWalletStatus(context.Background(), &node.EmptyRequest{})
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
 
 	// If we have no wallet loaded, we open the menu to load or
@@ -42,15 +67,16 @@ func main() {
 			// If we get an error from `LoadMenu`, it means we lost
 			// our connection to the node.
 			_, _ = fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
+			return err
 		}
 	}
 
 	// Once loaded, we open the menu for wallet operations.
 	if err := prompt.WalletMenu(client.NodeClient); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
 func handlePanic() {


### PR DESCRIPTION
# What is new
Added new flag to wallet cmd in order to allow for loading different dusk.toml

# Motivation
To be able to target multiple different nodes on testnet, this option will come in handy so we can target different nodes 

# How to test
Start a dusk node with testharness and run:
```
make build && ./bin/wallet --configpath=/tmp/localnet-(replace the new ID here)/node-9000/
```