### PR TITLE
Improvements for metrics cmd #549 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint: ## Lint the files
 test: ## Run unittests
 	@go test $(TFLAGS) -p 1 -short ${PKG_LIST}
 test-harness: ## Run harness tests
-	@go test -v --count=1 --test.timeout=0 ./harness/tests/... -args -enable -keepalive
+	@go test -v --count=1 --test.timeout=0 ./harness/tests/... -args -enable #-keepalive
 get-blindbid: ## download dusk-blindbidproof
 	@rm -rf ${PWD}/bin/blindbid-linux-amd64 || true
 	@wget -P ${PWD}/bin/ https://github.com/dusk-network/dusk-blindbidproof/releases/download/v0.1.0/blindbid-linux-amd64 && chmod +x ${PWD}/bin/blindbid-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint: ## Lint the files
 test: ## Run unittests
 	@go test $(TFLAGS) -p 1 -short ${PKG_LIST}
 test-harness: ## Run harness tests
-	@go test -v --count=1 --test.timeout=0 ./harness/tests/... -args -enable #-keepalive
+	@go test -v --count=1 --test.timeout=0 ./harness/tests/... -args -enable -keepalive
 get-blindbid: ## download dusk-blindbidproof
 	@rm -rf ${PWD}/bin/blindbid-linux-amd64 || true
 	@wget -P ${PWD}/bin/ https://github.com/dusk-network/dusk-blindbidproof/releases/download/v0.1.0/blindbid-linux-amd64 && chmod +x ${PWD}/bin/blindbid-linux-amd64

--- a/cmd/utils/main.go
+++ b/cmd/utils/main.go
@@ -56,8 +56,8 @@ var (
 
 	addressFlag = cli.StringFlag{
 		Name:  "address",
-		Usage: "Dusk address , eg: --address=0x123",
-		Value: "0x123",
+		Usage: "Dusk address , eg: --address=self",
+		Value: "self",
 	}
 
 	gqlPortFlag = cli.IntFlag{
@@ -153,8 +153,7 @@ func transactionsAction(ctx *cli.Context) error {
 
 	txHash := hex.EncodeToString(transferResponse.Hash)
 
-	log.WithField("transferResponse", transferResponse).
-		WithField("txHash", txHash).
+	log.WithField("txHash", txHash).
 		Info("transactions Action completed")
 
 	return nil

--- a/cmd/utils/main.go
+++ b/cmd/utils/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 
@@ -150,7 +151,10 @@ func transactionsAction(ctx *cli.Context) error {
 		return err
 	}
 
+	txHash := hex.EncodeToString(transferResponse.Hash)
+
 	log.WithField("transferResponse", transferResponse).
+		WithField("txHash", txHash).
 		Info("transactions Action completed")
 
 	return nil

--- a/cmd/utils/main.go
+++ b/cmd/utils/main.go
@@ -62,8 +62,8 @@ var (
 
 	gqlPortFlag = cli.IntFlag{
 		Name:  "gqlport",
-		Usage: "GQL PORT , eg: --gqlport=9503",
-		Value: 9503,
+		Usage: "GQL PORT , eg: --gqlport=9501",
+		Value: 9501,
 	}
 
 	nodePortFlag = cli.IntFlag{

--- a/cmd/utils/metrics/api.go
+++ b/cmd/utils/metrics/api.go
@@ -112,6 +112,11 @@ func getBlockByNumber(client *graphql.Client, values map[string]interface{}) (*B
 			height
 			timestamp
 		  }
+		  transactions {
+			txid
+			txtype
+			size
+		  }
 		}
 	  }
 	`

--- a/cmd/utils/metrics/metrics.go
+++ b/cmd/utils/metrics/metrics.go
@@ -12,6 +12,10 @@ import (
 	"github.com/machinebox/graphql"
 )
 
+const (
+	layoutISO = "2006-01-02 15:04:05 -0700 MST"
+)
+
 var (
 	lastBlockUpdate    time.Time
 	currentBlock       *Block
@@ -93,10 +97,10 @@ func Routine() {
 				continue
 			}
 
-			newTimestamp, _ := strconv.Atoi(newBlock.Header.Timestamp)
-			lastTimestamp, _ := strconv.Atoi(lastBlock.Header.Timestamp)
+			newTimestamp, _ := time.Parse(layoutISO, newBlock.Header.Timestamp)
+			lastTimestamp, _ := time.Parse(layoutISO, lastBlock.Header.Timestamp)
 
-			duskInfo.EffectiveBlockTime = int64(time.Unix(int64(newTimestamp), 0).Sub(time.Unix(int64(lastTimestamp), 0)).Seconds())
+			duskInfo.EffectiveBlockTime = int64(time.Unix(newTimestamp.Unix(), 0).Sub(time.Unix(lastTimestamp.Unix(), 0)).Seconds())
 			duskInfo.LoadTime = diff.Seconds()
 
 			continue
@@ -110,10 +114,10 @@ func Routine() {
 
 			lastBlock, _ := getBlockByNumber(gqlClient, map[string]interface{}{"height": previousBlockNum})
 
-			newTimestamp, _ := strconv.Atoi(newBlock.Header.Timestamp)
-			lastTimestamp, _ := strconv.Atoi(lastBlock.Header.Timestamp)
+			newTimestamp, _ := time.Parse(layoutISO, newBlock.Header.Timestamp)
+			lastTimestamp, _ := time.Parse(layoutISO, lastBlock.Header.Timestamp)
 
-			duskInfo.EffectiveBlockTime = int64(time.Unix(int64(newTimestamp), 0).Sub(time.Unix(int64(lastTimestamp), 0)).Seconds())
+			duskInfo.EffectiveBlockTime = int64(time.Unix(newTimestamp.Unix(), 0).Sub(time.Unix(lastTimestamp.Unix(), 0)).Seconds())
 
 			diff := lastBlockUpdate.Sub(t1)
 			duskInfo.LoadTime = diff.Seconds()

--- a/cmd/utils/tps.sh
+++ b/cmd/utils/tps.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# example for usage:
+# watch "./cmd/utils/tps.sh -q 4 -i 146512053 -p 8999"
+
+SCRIPT=$(basename ${BASH_SOURCE[0]})
+QTD=3
+PORT=9000
+ID=146512053
+
+usage() {
+  echo "Usage: $SCRIPT"
+  echo "Optional command line arguments"
+  echo "-q <number>  -- Quantity to run. eg: 3"
+  echo "-i <number>  -- ID of node. eg: 146512053"
+  echo "-p <number>  -- PORT of node. eg: 9000"
+
+  exit 1
+}
+
+while getopts "h?q:i:p:" args; do
+case $args in
+    h|\?)
+      usage;
+      exit;;
+    q ) QTD=${OPTARG};;
+    i ) ID=${OPTARG};;
+    p ) PORT=${OPTARG};;
+  esac
+done
+
+set -euxo pipefail
+
+sendtx_func() {
+  echo "sending transactions to node $i ..."
+  "$PWD"/bin/utils transactions --txtype=transfer --amount=1 --locktime=1 --grpchost=unix:///tmp/localnet-"${ID}"/node-$((PORT + i))/dusk-grpc.sock > /tmp/localnet-"${ID}"/tps.log 2>&1 & disown
+
+  TX_PID=$!
+  echo "sent transaction to node, pid=$TX_PID"
+}
+
+for i in $(seq 1 "$QTD"); do
+  sendtx_func "$i"
+done
+
+echo "done sending transactions to Dusk nodes"
+exit 0

--- a/cmd/utils/transactions/transactions.go
+++ b/cmd/utils/transactions/transactions.go
@@ -3,8 +3,9 @@ package transactions
 import (
 	"context"
 	"errors"
-	node "github.com/dusk-network/dusk-protobuf/autogen/go/node"
 	"time"
+
+	node "github.com/dusk-network/dusk-protobuf/autogen/go/node"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -49,9 +50,9 @@ func RunTransactions(grpcHost string, transaction Transaction) (*node.TransferRe
 
 		if transaction.Address == "self" {
 			log.WithField("transaction", transaction).Debug("Address defined as self, will go get node self address via grpc ...")
-			resp, err := client.GetAddress(context.Background(), &node.EmptyRequest{})
-			if err != nil {
-				return nil, err
+			resp, err1 := client.GetAddress(context.Background(), &node.EmptyRequest{})
+			if err1 != nil {
+				return nil, err1
 			}
 			log.WithField("address", string(resp.Key.PublicKey)).Info("Sending transfer tx to self address")
 			transaction.Address = string(resp.Key.PublicKey)


### PR DESCRIPTION
# Enhancements
* fix EffectiveBlockTime
* add tx encode
* fix send tx to send to self if not set
* fix BlockByNumber method to return also transactions
* update gql default port

# New
* Script to be used on testnet that can target multiple nodes, initially via unix socket, but to be updated and handle remote grpc connections.
* Usage:
```
./cmd/utils/tps.sh -h
Usage: tps.sh
Optional command line arguments
-q <number>  -- Quantity to run. eg: 3
-i <number>  -- ID of node. eg: 146512053
-p <number>  -- PORT of node. eg: 9000
```

## example for usage:
```
watch "./cmd/utils/tps.sh -q 4 -i 146512053 -p 8999"
```

## How to test

1. Start a small network of nodes with test-harness keepalive
```
make get-blindbid 
make build
NETWORK_SIZE=3 DUSK_BLOCKCHAIN=${PWD}/bin/dusk DUSK_BLINDBID=${PWD}/bin/blindbid-linux-amd64 DUSK_SEEDER=${PWD}/bin/voucher DUSK_WALLET_PASS="password" go test -v --count=1 --test.timeout=0 ./harness/tests/... -args -enable -keepalive
```

2. Start metrics collection:
```
make build && ./bin/utils metrics
```

3. Start generating transactions:
```
watch "./cmd/utils/tps.sh -q 4 -i 990933551 -p 8999"
```

4. Hit the metrics endpoint and observe transactions being generated and stats being collected:
```
watch "curl http://localhost:9099/metrics"
```

* Example metrics output:
```
$ curl http://localhost:9099/metrics
dusk_block 254
dusk_seconds_last_block 2.30
dusk_effective_block_time 2
dusk_block_transactions 9
dusk_block_tps 4
dusk_block_value 0
dusk_block_size_bytes 0
dusk_pending_transactions 0
dusk_contracts_created 0
dusk_token_transfers 0
dusk_transfers 0
dusk_load_time 0.0137
```
