### PR TITLE
Add script to facilitate devnet without test harness #566

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ demo/**.*
 
 # Testnet binary
 launch/testnet/testnet
+
+devnet

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ mockrusk: build
 	./bin/utils mockrusk --rusknetwork=tcp --ruskaddress=127.0.0.1:10000 \
 	--walletstore=/tmp/localnet-137601832/node-9003/walletDB/ \
 	--walletfile=./harness/data/wallet-9000.dat
+devnet: stop
+	./devnet.sh
 stop:
 	echo "will stop dusk app"
 	killall dusk || true

--- a/cmd/utils/main.go
+++ b/cmd/utils/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dusk-network/dusk-blockchain/cmd/utils/walletutils"
+
 	"github.com/dusk-network/dusk-blockchain/cmd/utils/mock"
 
 	"github.com/dusk-network/dusk-blockchain/cmd/utils/transactions"
@@ -25,6 +27,7 @@ func main() {
 		transactionsCMD,
 		mockCMD,
 		mockRUSKCMD,
+		walletUtilsCMD,
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -116,6 +119,18 @@ var (
 		Value: "./harness/data/wallet-9000.dat",
 	}
 
+	walletCMDFlag = cli.StringFlag{
+		Name:  "walletcmd",
+		Usage: "Dusk WalletCmd , eg: --walletcmd=loadwallet",
+		Value: "loadwallet",
+	}
+
+	walletPasswordFlag = cli.StringFlag{
+		Name:  "walletpassword",
+		Usage: "Dusk Wallet Password, eg: --walletpassword=password",
+		Value: "password",
+	}
+
 	metricsCMD = cli.Command{
 		Name:      "metrics",
 		Usage:     "expose a metrics endpoint",
@@ -168,6 +183,19 @@ var (
 			walletFileFlag,
 		},
 		Description: `Execute/Query transactions for a Dusk node`,
+	}
+
+	walletUtilsCMD = cli.Command{
+		Name:      "walletutils",
+		Usage:     "execute cmd to a Dusk wallet",
+		Action:    walletAction,
+		ArgsUsage: "",
+		Flags: []cli.Flag{
+			grpcHostFlag,
+			walletCMDFlag,
+			walletPasswordFlag,
+		},
+		Description: `Execute/Query a Dusk wallet`,
 	}
 )
 
@@ -232,5 +260,21 @@ func mockRuskAction(ctx *cli.Context) error {
 	walletFile := ctx.String(walletFileFlag.Name)
 
 	err := mock.RunRUSKMock(ruskNetwork, ruskAddress, walletStore, walletFile)
+	return err
+}
+
+func walletAction(ctx *cli.Context) error {
+
+	grpcHost := ctx.String(grpcHostFlag.Name)
+	walletCMD := ctx.String(walletCMDFlag.Name)
+	walletPassword := ctx.String(walletPasswordFlag.Name)
+
+	log.WithField("walletCMD", walletCMD).
+		Info("wallet Action started")
+
+	resp, err := walletutils.RunWallet(grpcHost, walletCMD, walletPassword)
+
+	log.WithField("resp", resp).
+		Info("wallet Action completed")
 	return err
 }

--- a/cmd/utils/walletutils/wallet.go
+++ b/cmd/utils/walletutils/wallet.go
@@ -1,0 +1,42 @@
+package walletutils
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dusk-network/dusk-protobuf/autogen/go/node"
+
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// RunWallet will run cmds against a dusk wallet
+func RunWallet(grpcHost, walletCMD, walletPassword string) (*node.LoadResponse, error) {
+
+	// Set up a connection to the server.
+	conn, err := grpc.Dial(grpcHost, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	client := node.NewWalletClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if walletCMD == "loadwallet" {
+
+		req := node.LoadRequest{Password: walletPassword}
+		resp, err := client.LoadWallet(ctx, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		return resp, nil
+	}
+
+	return nil, errors.New("not yet implemented")
+}

--- a/devnet.sh
+++ b/devnet.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+SCRIPT=$(basename ${BASH_SOURCE[0]})
+QTD=2 #QTD=2 == 3 nodes since it counts from zero
+TYPE=branch
+DUSK_VERSION=v0.3.0
+INIT=true
+MOCK=true
+
+# define command exec location
+duskCMD="../bin/dusk"
+
+usage() {
+  echo "Usage: $SCRIPT"
+  echo "Optional command line arguments"
+  echo "-c <number>  -- TYPE to use. eg: release"
+  echo "-q <number>  -- QTD of validators to run. eg: 5"
+  echo "-s <number>  -- DUSK_VERSION version. eg: v0.3.0"
+  echo "-i <number>  -- INIT instances (true or false). eg: true"
+  echo "-m <number>  -- MOCK instances (true or false). eg: true"
+
+  exit 1
+}
+
+while getopts "h?c:q:s:i:m:" args; do
+case $args in
+    h|\?)
+      usage;
+      exit;;
+    c ) TYPE=${OPTARG};;
+    q ) QTD=${OPTARG};;
+    s ) DUSK_VERSION=${OPTARG};;
+    i ) INIT=${OPTARG};;
+    m ) MOCK=${OPTARG};;
+  esac
+done
+
+set -euxo pipefail
+
+if [ "${TYPE}" == "branch" ]; then
+  GOBIN=$(pwd)/bin go run scripts/build.go install
+fi
+
+#init dusk
+init_dusk_func() {
+  echo "init Dusk node $i ..."
+  currentDir=$(pwd)
+  DDIR="${currentDir}/devnet/dusk_data/dusk${i}"
+  LOGS="${currentDir}/devnet/dusk_data/logs"
+
+  # cleanup
+  rm -rf "${DDIR}"
+  rm -rf "${LOGS}"
+
+  mkdir -p "${DDIR}"
+  mkdir -p "${LOGS}"
+  cat <<EOF > "${DDIR}"/dusk.toml
+[consensus]
+  defaultamount = 50
+  defaultlocktime = 1000
+  defaultoffset = 10
+
+[database]
+  dir = "${DDIR}/chain/"
+  driver = "heavy_v0.1.0"
+
+[general]
+  network = "testnet"
+  walletonly = "false"
+
+[genesis]
+  legacy = true
+
+[gql]
+  address = "127.0.0.1:$((9500+$i))"
+  enabled = "true"
+  network = "tcp"
+
+[logger]
+  output = "${DDIR}/dusk"
+
+[mempool]
+  maxinvitems = "10000"
+  maxsizemb = "100"
+  pooltype = "hashmap"
+  prealloctxs = "100"
+
+[network]
+  port = "$((7100+$i))"
+
+  [network.seeder]
+    addresses = ["127.0.0.1:8081"]
+
+[rpc]
+  address = "${DDIR}/dusk-grpc.sock"
+  enabled = "true"
+  network = "unix"
+
+  [rpc.rusk]
+    address = "127.0.0.1:$((10000+$i))"
+    contracttimeout = 6000
+    defaulttimeout = 1000
+    network = "tcp"
+
+[wallet]
+  file = "${currentDir}/harness/data/wallet-$((9000+$i)).dat"
+  store = "${DDIR}/walletDB/"
+EOF
+
+  echo "init Dusk node, done."
+}
+
+# start dusk mocks
+start_dusk_mock_func() {
+  echo "starting Dusk mocks $i ..."
+
+#  EXEC_PID=$!
+#  echo "started Dusk node, pid=$EXEC_PID"
+}
+
+# start dusk
+start_dusk_func() {
+  echo "starting Dusk node $i ..."
+
+#  EXEC_PID=$!
+#  echo "started Dusk node, pid=$EXEC_PID"
+}
+
+if [ "${INIT}" == "true" ]; then
+
+  for i in $(seq 0 "$QTD"); do
+    init_dusk_func "$i"
+  done
+
+fi
+
+sleep 2
+
+if [ "${MOCK}" == "true" ]; then
+  for i in $(seq 0 "$QTD"); do
+    start_dusk_mock_func "$i"
+  done
+fi
+
+for i in $(seq 0 "$QTD"); do
+  start_dusk_func "$i"
+done
+
+echo "done starting Dusk stack"
+exit 0

--- a/devnet.sh
+++ b/devnet.sh
@@ -141,6 +141,12 @@ start_dusk_func() {
 
   EXEC_PID=$!
   echo "started Dusk node $i, pid=$EXEC_PID"
+  sleep 1
+
+  # load wallet cmd
+  LOADWALLET_CMD="./bin/utils walletutils --grpchost unix://${DDIR}/dusk-grpc.sock --walletcmd loadwallet --walletpassword password"
+  ${LOADWALLET_CMD} >> "${currentDir}/devnet/dusk_data/logs/load_wallet$i.log" 2>&1 &
+
 }
 
 start_dusk_mock_func() {


### PR DESCRIPTION
## Whats new
New script to start a local dev net:
`make devnet`

New script to load wallet via cmd line:
`make build && ./bin/utils walletutils --grpchost unix://opt/gocode/src/github.com/dusk-network/dusk-blockchain/devnet/dusk_data/dusk0/dusk-grpc.sock --walletcmd loadwallet --walletpassword password`


# issues
closes: #568
closes: #566