### PR TITLE
Utilize chain-race detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-harness-alive: stop build
 	MOCK_ADDRESS=127.0.0.1:9191 NETWORK_SIZE=3 DUSK_BLOCKCHAIN=${PWD}/bin/dusk DUSK_UTILS=${PWD}/bin/utils DUSK_SEEDER=${PWD}/bin/voucher DUSK_WALLET_PASS="password" \
 	go test -v --count=1 --test.timeout=0 ./harness/tests/ -args -enable -keepalive
 test-harness-race-alive: stop build-race
-	MOCK_ADDRESS=127.0.0.1:9191 NETWORK_SIZE=3 DUSK_BLOCKCHAIN=${PWD}/bin/dusk DUSK_UTILS=${PWD}/bin/utils DUSK_SEEDER=${PWD}/bin/voucher DUSK_WALLET_PASS="password" \
+	MOCK_ADDRESS=127.0.0.1:9191 NETWORK_SIZE=9 DUSK_BLOCKCHAIN=${PWD}/bin/dusk DUSK_UTILS=${PWD}/bin/utils DUSK_SEEDER=${PWD}/bin/voucher DUSK_WALLET_PASS="password" \
 	go test -v --count=1 --test.timeout=0 ./harness/tests/ -args -enable -keepalive
 race: dep ## Run data race detector
 	@go test $(TFLAGS) -race -v ${PKG_LIST}

--- a/harness/engine/network.go
+++ b/harness/engine/network.go
@@ -68,7 +68,7 @@ func (n *Network) Bootstrap(workspace string) error {
 
 	if MOCK_ADDRESS != "" {
 		// Run mock process
-		if bbErr := n.start("", utilsExec, "mock",
+		if bbErr := n.start(workspace, utilsExec, "mock",
 			"--grpcmockhost", MOCK_ADDRESS,
 		); bbErr != nil {
 			return bbErr
@@ -129,7 +129,7 @@ func (n *Network) StartNode(i int, node *DuskNode, workspace string) error {
 
 	if MOCK_ADDRESS != "" {
 		// Start the mock RUSK server
-		if startErr := n.start("", utilsExec, "mockrusk",
+		if startErr := n.start(nodeDir, utilsExec, "mockrusk",
 			"--rusknetwork", node.Cfg.RPC.Rusk.Network,
 			"--ruskaddress", node.Cfg.RPC.Rusk.Address,
 			"--walletstore", node.Cfg.Wallet.Store,

--- a/harness/tests/localnet_test.go
+++ b/harness/tests/localnet_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"encoding/hex"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -87,35 +86,14 @@ func TestSendBidTransaction(t *testing.T) {
 		}
 	}
 
-	t.Log("Send request to node 0 to generate and process a Bid transaction")
-	txidBytes, err := localNet.SendBidCmd(0, 10, 10)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	txID := hex.EncodeToString(txidBytes)
-	t.Logf("Bid transaction id: %s", txID)
-
-	t.Log("Ensure all nodes have accepted this transaction at the same height")
-	blockhash := ""
-	for i := 0; i < len(localNet.Nodes); i++ {
-
-		bh := localNet.WaitUntilTx(t, uint(i), txID)
-
-		if len(bh) == 0 {
-			t.Fatal("empty blockhash")
-		}
-
-		if len(blockhash) != 0 && blockhash != bh {
-			// the case where the network has inconsistency and same tx has been
-			// accepted within different blocks
-			t.Fatal("same tx hash has been accepted within different blocks")
-		}
-
-		if i == 0 {
-			blockhash = bh
+	for i := 0; i < localNetSize; i++ {
+		t.Logf("Send request to node %d to generate and process a Bid transaction", i)
+		_, err := localNet.SendBidCmd(uint(i), 10, 10)
+		if err != nil {
+			continue
 		}
 	}
+
 }
 
 // TestCatchup tests that a node which falls behind during consensus

--- a/harness/tests/localnet_test.go
+++ b/harness/tests/localnet_test.go
@@ -88,11 +88,13 @@ func TestSendBidTransaction(t *testing.T) {
 
 	for i := 0; i < localNetSize; i++ {
 		t.Logf("Send request to node %d to generate and process a Bid transaction", i)
-		_, err := localNet.SendBidCmd(uint(i), 10, 10)
-		if err != nil {
-			continue
-		}
+
+		go func(i int) {
+			localNet.SendBidCmd(uint(i), 10, 10)
+		}(i)
 	}
+
+	time.Sleep(5 * time.Second)
 
 }
 

--- a/pkg/core/consensus/selection/selector.go
+++ b/pkg/core/consensus/selection/selector.go
@@ -54,7 +54,7 @@ func (e emptyScoreFactory) Create(pubkey []byte, round uint64, step uint8) conse
 // the topic BestScoreTopic
 func NewComponent(ctx context.Context, publisher eventbus.Publisher, timeout time.Duration, provisioner transactions.Provisioner) *Selector {
 	return &Selector{
-		timeout:     timeout,
+		timeout:     time.Second,
 		publisher:   publisher,
 		bestEvent:   message.EmptyScore(),
 		ctx:         ctx,

--- a/pkg/util/legacy/conversions.go
+++ b/pkg/util/legacy/conversions.go
@@ -396,6 +396,8 @@ func ruskInputsToInputs(inputs []*rusk.TransactionInput) (transactions.Inputs, e
 	sInputs := make(transactions.Inputs, len(inputs))
 
 	for i, input := range inputs {
+		sInputs[i] = new(transactions.Input)
+
 		buf := bytes.NewBuffer(input.Nullifier.H.Data)
 		keyImageBytes := make([]byte, 32)
 		if err := encoding.Read256(buf, keyImageBytes); err != nil {


### PR DESCRIPTION
Steps to follow:

1. make test-harness-race-alive
2. tail -F /tmp/localnet-\*/node-900\*/dusk_stderr  


Races below occur after four rounds 


Race 1:

```
==================
WARNING: DATA RACE
Write at 0x00c00019e180 by goroutine 90:
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:266 +0x2f4
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock-fm()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:234 +0x55
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*CallbackListener).Notify()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/listener.go:32 +0x10b
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*EventBus).Publish()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/publisher.go:30 +0x363
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer/processing/chainsync.(*ChainSynchronizer).Synchronize()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/processing/chainsync/sync.go:104 +0x772
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).route()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:70 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).Collect()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:40 +0x1be
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).readLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:269 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).ReadLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:226 +0x6c

Previous write at 0x00c00019e180 by goroutine 58:
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:266 +0x2f4
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock-fm()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:234 +0x55
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*CallbackListener).Notify()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/listener.go:32 +0x10b
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*EventBus).Publish()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/publisher.go:30 +0x363
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer/processing/chainsync.(*ChainSynchronizer).Synchronize()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/processing/chainsync/sync.go:104 +0x772
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).route()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:70 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).Collect()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:40 +0x1be
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).readLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:269 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).ReadLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:226 +0x6c

Goroutine 90 (running) created at:
  main.(*Server).OnConnection()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:234 +0x81b
  main.(*Server).OnConnection-fm()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:217 +0x69

Goroutine 58 (running) created at:
  main.(*Server).OnConnection()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:234 +0x81b
  main.(*Server).OnConnection-fm()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:217 +0x69
==================
```


Race 2:

```
==================
WARNING: DATA RACE
Write at 0x00c000225560 by goroutine 66:
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).requestRoundResults()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:512 +0x80e
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:260 +0x271
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock-fm()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:234 +0x55
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*CallbackListener).Notify()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/listener.go:32 +0x10b
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*EventBus).Publish()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/publisher.go:30 +0x363
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer/processing/chainsync.(*ChainSynchronizer).Synchronize()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/processing/chainsync/sync.go:104 +0x772
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).route()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:70 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).Collect()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:40 +0x1be
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).readLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:269 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).ReadLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:226 +0x6c

Previous write at 0x00c000225560 by goroutine 74:
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).requestRoundResults()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:512 +0x80e
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:260 +0x271
  github.com/dusk-network/dusk-blockchain/pkg/core/chain.(*Chain).onAcceptBlock-fm()
      rusk-ipc/dusk-blockchain/pkg/core/chain/chain.go:234 +0x55
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*CallbackListener).Notify()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/listener.go:32 +0x10b
  github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus.(*EventBus).Publish()
      rusk-ipc/dusk-blockchain/pkg/util/nativeutils/eventbus/publisher.go:30 +0x363
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer/processing/chainsync.(*ChainSynchronizer).Synchronize()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/processing/chainsync/sync.go:104 +0x772
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).route()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:70 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*messageRouter).Collect()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/router.go:40 +0x1be
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).readLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:269 +0x402
  github.com/dusk-network/dusk-blockchain/pkg/p2p/peer.(*Reader).ReadLoop()
      rusk-ipc/dusk-blockchain/pkg/p2p/peer/peer.go:226 +0x6c

Goroutine 66 (running) created at:
  main.(*Server).OnConnection()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:234 +0x81b
  main.(*Server).OnConnection-fm()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:217 +0x69

Goroutine 74 (running) created at:
  main.(*Server).OnConnection()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:234 +0x81b
  main.(*Server).OnConnection-fm()
      rusk-ipc/dusk-blockchain/cmd/dusk/server.go:217 +0x69
==================

```