### PR TITLE
Synchronize access to the 'Halt' method

### DIFF
--- a/pkg/core/consensus/reduction/firststep/aggregator_test.go
+++ b/pkg/core/consensus/reduction/firststep/aggregator_test.go
@@ -14,7 +14,7 @@ import (
 // TestSuccessfulAggro tests that upon collection of a quorum of events, a valid StepVotes get produced
 func TestSuccessfulAggro(t *testing.T) {
 	eb, rbus := eventbus.New(), rpcbus.New()
-	hlp, hash := Kickstart(eb, rbus, 10, 1*time.Second, true)
+	hlp, hash := KickstartConcurrent(eb, rbus, 10, 1*time.Second)
 	evs := hlp.Spawn(hash)
 
 	res := make(chan reduction.HaltMsg, 1)
@@ -36,7 +36,7 @@ func TestSuccessfulAggro(t *testing.T) {
 func TestInvalidBlock(t *testing.T) {
 	logrus.SetLevel(logrus.FatalLevel)
 	eb, rbus := eventbus.New(), rpcbus.New()
-	hlp, hash := Kickstart(eb, rbus, 10, 1*time.Second, true)
+	hlp, hash := KickstartConcurrent(eb, rbus, 10, 1*time.Second)
 	hlp.FailOnVerification(true)
 	evs := hlp.Spawn(hash)
 
@@ -59,7 +59,7 @@ func TestInvalidBlock(t *testing.T) {
 // a given hash is not found.
 func TestCandidateNotFound(t *testing.T) {
 	eb, rbus := eventbus.New(), rpcbus.New()
-	hlp, hash := Kickstart(eb, rbus, 10, 1*time.Second, true)
+	hlp, hash := KickstartConcurrent(eb, rbus, 10, 1*time.Second)
 	hlp.FailOnFetching(true)
 	evs := hlp.Spawn(hash)
 

--- a/pkg/core/consensus/reduction/firststep/reduction_test.go
+++ b/pkg/core/consensus/reduction/firststep/reduction_test.go
@@ -2,6 +2,7 @@ package firststep
 
 import (
 	"bytes"
+	"runtime"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestMoreSteps(t *testing.T) {
 func TestFirstStepTimeOut(t *testing.T) {
 	bus, rpcBus := eventbus.New(), rpcbus.New()
 	timeOut := 100 * time.Millisecond
-	hlp, _ := Kickstart(bus, rpcBus, 50, timeOut)
+	hlp, _ := Kickstart(bus, rpcBus, 50, timeOut, true)
 
 	// Wait for resulting StepVotes
 	svMsg := <-hlp.StepVotesChan
@@ -85,7 +86,7 @@ func TestFirstStepTimeOut(t *testing.T) {
 
 func BenchmarkFirstStep(b *testing.B) {
 	bus, rpcBus := eventbus.New(), rpcbus.New()
-	hlp, hash := Kickstart(bus, rpcBus, 50, 1*time.Second)
+	hlp, hash := Kickstart(bus, rpcBus, 50, 1*time.Second, true)
 	b.ResetTimer()
 	b.StopTimer()
 	for i := 0; i < b.N; i++ {
@@ -99,4 +100,22 @@ func BenchmarkFirstStep(b *testing.B) {
 		hash, _ = crypto.RandEntropy(32)
 		hlp.ActivateReduction(hash)
 	}
+}
+
+// Test that we properly clean up after calling Finalize.
+// TODO: trap eventual errors
+func TestFinalize(t *testing.T) {
+	numGRBefore := runtime.NumGoroutine()
+	// Create a set of 100 agreement components, and finalize them immediately
+	for i := 0; i < 100; i++ {
+		bus, rpcBus := eventbus.New(), rpcbus.New()
+		hlp, _ := Kickstart(bus, rpcBus, 50, 1*time.Second, false)
+
+		hlp.Reducer.Finalize()
+	}
+
+	// Ensure we have freed up all of the resources associated with these components
+	numGRAfter := runtime.NumGoroutine()
+	// We should have roughly the same amount of goroutines
+	assert.InDelta(t, numGRBefore, numGRAfter, 10.0)
 }

--- a/pkg/core/consensus/reduction/firststep/reduction_test.go
+++ b/pkg/core/consensus/reduction/firststep/reduction_test.go
@@ -66,7 +66,7 @@ func TestMoreSteps(t *testing.T) {
 func TestFirstStepTimeOut(t *testing.T) {
 	bus, rpcBus := eventbus.New(), rpcbus.New()
 	timeOut := 100 * time.Millisecond
-	hlp, _ := Kickstart(bus, rpcBus, 50, timeOut, true)
+	hlp, _ := KickstartConcurrent(bus, rpcBus, 50, timeOut)
 
 	// Wait for resulting StepVotes
 	svMsg := <-hlp.StepVotesChan
@@ -86,7 +86,7 @@ func TestFirstStepTimeOut(t *testing.T) {
 
 func BenchmarkFirstStep(b *testing.B) {
 	bus, rpcBus := eventbus.New(), rpcbus.New()
-	hlp, hash := Kickstart(bus, rpcBus, 50, 1*time.Second, true)
+	hlp, hash := KickstartConcurrent(bus, rpcBus, 50, 1*time.Second)
 	b.ResetTimer()
 	b.StopTimer()
 	for i := 0; i < b.N; i++ {
@@ -109,7 +109,7 @@ func TestFinalize(t *testing.T) {
 	// Create a set of 100 agreement components, and finalize them immediately
 	for i := 0; i < 100; i++ {
 		bus, rpcBus := eventbus.New(), rpcbus.New()
-		hlp, _ := Kickstart(bus, rpcBus, 50, 1*time.Second, false)
+		hlp, _ := Kickstart(bus, rpcBus, 50, 1*time.Second)
 
 		hlp.Reducer.Finalize()
 	}

--- a/pkg/core/consensus/reduction/firststep/testutil.go
+++ b/pkg/core/consensus/reduction/firststep/testutil.go
@@ -25,7 +25,9 @@ type Helper struct {
 	failOnVerification bool
 }
 
-// NewHelper creates a Helper
+// NewHelper creates a Helper used for testing the first step Reducer.
+// `startGoroutines` can be specified to simultaneously launch goroutines
+// that intercept RPC calls made by the first step Reducer.
 func NewHelper(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, provisioners int, timeOut time.Duration, startGoroutines bool) *Helper {
 	hlp := &Helper{
 		Helper:             reduction.NewHelper(eb, rpcbus, provisioners, CreateReducer, timeOut),

--- a/pkg/core/consensus/reduction/reducer.go
+++ b/pkg/core/consensus/reduction/reducer.go
@@ -1,6 +1,15 @@
 package reduction
 
-import "github.com/dusk-network/dusk-blockchain/pkg/core/consensus"
+import (
+	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
+)
+
+// HaltMsg is used to communicate between reducers, and aggregators and timers.
+type HaltMsg struct {
+	Hash []byte
+	Sv   []*message.StepVotes
+}
 
 // Reducer abstracts the first and second step Reduction components
 type Reducer interface {

--- a/pkg/core/consensus/reduction/secondstep/reduction_test.go
+++ b/pkg/core/consensus/reduction/secondstep/reduction_test.go
@@ -1,6 +1,7 @@
 package secondstep
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -38,7 +39,7 @@ func TestSecondStep(t *testing.T) {
 }
 
 func TestSecondStepAfterFailure(t *testing.T) {
-	timeOut := 1000 * time.Millisecond
+	timeOut := 100 * time.Millisecond
 	hlp, hash := Kickstart(50, timeOut)
 
 	// Start the first step
@@ -61,4 +62,26 @@ func TestSecondStepAfterFailure(t *testing.T) {
 		assert.Equal(t, timeOut*2, hlp.Reducer.(*Reducer).timeOut)
 		// Success
 	}
+}
+
+// Test that we properly clean up after calling Finalize.
+// TODO: trap eventual errors
+func TestFinalize(t *testing.T) {
+	numGRBefore := runtime.NumGoroutine()
+	// Create a set of 100 reduction components, and finalize them immediately
+	for i := 0; i < 100; i++ {
+		hlp, hash := Kickstart(50, 1*time.Second)
+
+		// Start the first step
+		if err := hlp.ActivateReduction(hash, message.StepVotes{}); err != nil {
+			t.Fatal(err)
+		}
+
+		hlp.Reducer.Finalize()
+	}
+
+	// Ensure we have freed up all of the resources associated with these components
+	numGRAfter := runtime.NumGoroutine()
+	// We should have roughly the same amount of goroutines
+	assert.InDelta(t, numGRBefore, numGRAfter, 10.0)
 }

--- a/pkg/core/consensus/reduction/timer.go
+++ b/pkg/core/consensus/reduction/timer.go
@@ -13,15 +13,15 @@ var emptyHash [32]byte
 // Timer sets a timeout for collecting reduction messages if no quorum is
 // reached after a while
 type Timer struct {
-	requestHalt func([]byte, ...*message.StepVotes)
-	lock        sync.RWMutex
-	t           *time.Timer
+	haltChan chan<- HaltMsg
+	lock     sync.RWMutex
+	t        *time.Timer
 }
 
 // NewTimer instantiates a new Timer
-func NewTimer(requestHalt func([]byte, ...*message.StepVotes)) *Timer {
+func NewTimer(haltChan chan<- HaltMsg) *Timer {
 	return &Timer{
-		requestHalt: requestHalt,
+		haltChan: haltChan,
 	}
 }
 
@@ -44,5 +44,8 @@ func (t *Timer) Stop() {
 // Trigger the timeout and requests a halt with empty block hash
 func (t *Timer) Trigger() {
 	log.WithField("process", "reduction timer").Debugln("timer triggered")
-	t.requestHalt(emptyHash[:])
+	t.haltChan <- HaltMsg{
+		Hash: emptyHash[:],
+		Sv:   []*message.StepVotes{},
+	}
 }

--- a/pkg/core/consensus/reduction/timer_test.go
+++ b/pkg/core/consensus/reduction/timer_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/reduction"
-	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 	"github.com/stretchr/testify/assert"
 )
 
 // Ensure that stopping a timer which was never started does not result
 // in a panic.
 func TestStopNilTimer(t *testing.T) {
-	timer := reduction.NewTimer(func([]byte, ...*message.StepVotes) {})
+	c := make(chan reduction.HaltMsg, 1)
+	timer := reduction.NewTimer(c)
 	assert.NotPanics(t, timer.Stop)
 }


### PR DESCRIPTION
This should fix a possible race condition between the timer
and the aggregator, who could previously both call 'Halt'
at the same time, causing consensus desyncs.
Fixes #565