### PR TITLE
Increase timeout for TestFirstStep in order to avoid it failing sometimes on CI

### DIFF
--- a/pkg/core/consensus/reduction/firststep/reduction_test.go
+++ b/pkg/core/consensus/reduction/firststep/reduction_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestFirstStep(t *testing.T) {
 	bus, rpcBus := eventbus.New(), rpcbus.New()
-	hlp, hash := ProduceFirstStepVotes(bus, rpcBus, 50, 1*time.Second)
+	hlp, hash := ProduceFirstStepVotes(bus, rpcBus, 50, 2*time.Second)
 	// test that EventPlayer.Play has been called
 	assert.Equal(t, uint8(1), hlp.Step())
 
@@ -37,7 +37,7 @@ func TestFirstStep(t *testing.T) {
 	// test that the Player is PAUSED
 	assert.Equal(t, consensus.PAUSED, hlp.State())
 	// test that the timeout is still 1 second
-	assert.Equal(t, 1*time.Second, hlp.Reducer.(*Reducer).timeOut)
+	assert.Equal(t, 2*time.Second, hlp.Reducer.(*Reducer).timeOut)
 }
 
 func TestMoreSteps(t *testing.T) {

--- a/pkg/core/consensus/reduction/firststep/testutil.go
+++ b/pkg/core/consensus/reduction/firststep/testutil.go
@@ -125,16 +125,16 @@ func (hlp *Helper) NextBatch() []byte {
 
 // Kickstart a Helper without sending any reduction event, and without starting goroutines to
 // intercept RPCBus calls.
-func Kickstart(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, nr int, timeOut time.Duration) (*Helper, []byte) {
-	h := NewHelper(eb, rpcbus, nr, timeOut, false)
+func Kickstart(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, provisioners int, timeOut time.Duration) (*Helper, []byte) {
+	h := NewHelper(eb, rpcbus, provisioners, timeOut, false)
 	hash := kickstart(h)
 	return h, hash
 }
 
 // KickstartConcurrent kickstarts a Helper without sending any reduction event, starting
 // goroutines to intercept RPCBus calls.
-func KickstartConcurrent(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, nr int, timeOut time.Duration) (*Helper, []byte) {
-	h := NewHelper(eb, rpcbus, nr, timeOut, true)
+func KickstartConcurrent(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, provisioners int, timeOut time.Duration) (*Helper, []byte) {
+	h := NewHelper(eb, rpcbus, provisioners, timeOut, true)
 	hash := kickstart(h)
 	return h, hash
 }
@@ -148,8 +148,8 @@ func kickstart(h *Helper) []byte {
 }
 
 // ProduceFirstStepVotes encapsulates the process of creating and forwarding Reduction events
-func ProduceFirstStepVotes(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, nr int, timeOut time.Duration) (*Helper, []byte) {
-	hlp, hash := KickstartConcurrent(eb, rpcbus, nr, timeOut)
+func ProduceFirstStepVotes(eb *eventbus.EventBus, rpcbus *rpcbus.RPCBus, provisioners int, timeOut time.Duration) (*Helper, []byte) {
+	hlp, hash := KickstartConcurrent(eb, rpcbus, provisioners, timeOut)
 	hlp.SendBatch(hash)
 	return hlp, hash
 }


### PR DESCRIPTION
rename few vars on testutil.go to use same convention as in NewHelper func