### PR TITLE
Add Peer connected stats, Remove useless logic from NewReader method 

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -220,13 +220,10 @@ func launchDupeMap(eventBus eventbus.Broker) *dupemap.DupeMap {
 func (s *Server) OnAccept(conn net.Conn) {
 	writeQueueChan := make(chan *bytes.Buffer, 1000)
 	exitChan := make(chan struct{}, 1)
-	peerReader, err := peer.NewReader(conn, s.gossip, s.dupeMap, s.eventBus, s.rpcBus, s.counter, writeQueueChan, exitChan)
-	if err != nil {
-		panic(err)
-	}
+	peerReader := peer.NewReader(conn, s.gossip, s.dupeMap, s.eventBus, s.rpcBus, s.counter, writeQueueChan, exitChan)
 
 	if err := peerReader.Accept(); err != nil {
-		logServer.WithError(err).Warnln("problem performing handshake")
+		logServer.WithError(err).Warnln("OnAccept, problem performing handshake")
 		return
 	}
 	logServer.WithField("address", peerReader.Addr()).Debugln("connection established")
@@ -243,7 +240,7 @@ func (s *Server) OnConnection(conn net.Conn, addr string) {
 	peerWriter := peer.NewWriter(conn, s.gossip, s.eventBus)
 
 	if err := peerWriter.Connect(); err != nil {
-		logServer.WithError(err).Warnln("problem performing handshake")
+		logServer.WithError(err).Warnln("OnConnection, problem performing handshake")
 		return
 	}
 	address := peerWriter.Addr()
@@ -251,10 +248,7 @@ func (s *Server) OnConnection(conn net.Conn, addr string) {
 		Debugln("connection established")
 
 	exitChan := make(chan struct{}, 1)
-	peerReader, err := peer.NewReader(conn, s.gossip, s.dupeMap, s.eventBus, s.rpcBus, s.counter, writeQueueChan, exitChan)
-	if err != nil {
-		log.Panic(err)
-	}
+	peerReader := peer.NewReader(conn, s.gossip, s.dupeMap, s.eventBus, s.rpcBus, s.counter, writeQueueChan, exitChan)
 
 	go peerReader.ReadLoop()
 	go peerWriter.Serve(writeQueueChan, exitChan)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -111,6 +111,7 @@ func (s *Server) InitRouting() *pat.Router {
 	r.HandleFunc("/consensus/roundinfo", capi.GetRoundInfoHandler).Methods("GET")
 	r.HandleFunc("/consensus/eventqueuestatus", capi.GetEventQueueStatusHandler).Methods("GET")
 	r.HandleFunc("/p2p/logs", capi.GetP2PLogsHandler).Methods("GET")
+	r.HandleFunc("/p2p/count", capi.GetP2PCountHandler).Methods("GET")
 
 	return r
 }

--- a/pkg/core/consensus/capi/api.go
+++ b/pkg/core/consensus/capi/api.go
@@ -194,9 +194,8 @@ func GetP2PLogsHandler(res http.ResponseWriter, req *http.Request) {
 	_, _ = res.Write(b)
 }
 
+// GetP2PCountHandler will return the current peer count
 func GetP2PCountHandler(res http.ResponseWriter, req *http.Request) {
-	log.Debug("GetP2PCountHandler")
-
 	peersCount, err := GetStormDBInstance().DB.Count(&PeerCount{})
 	if err != nil {
 		log.WithError(err).Debug("failed to count peers")

--- a/pkg/core/consensus/capi/api.go
+++ b/pkg/core/consensus/capi/api.go
@@ -193,3 +193,27 @@ func GetP2PLogsHandler(res http.ResponseWriter, req *http.Request) {
 
 	_, _ = res.Write(b)
 }
+
+func GetP2PCountHandler(res http.ResponseWriter, req *http.Request) {
+	log.Debug("GetP2PCountHandler")
+
+	peersCount, err := GetStormDBInstance().DB.Count(&PeerCount{})
+	if err != nil {
+		log.WithError(err).Debug("failed to count peers")
+		res.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	count := Count{
+		Count: peersCount,
+	}
+
+	var b []byte
+	b, err = json.Marshal(count)
+	if err != nil {
+		res.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	_, _ = res.Write(b)
+}

--- a/pkg/core/consensus/capi/model.go
+++ b/pkg/core/consensus/capi/model.go
@@ -36,6 +36,14 @@ type PeerJSON struct {
 	LastSeen time.Time `storm:"index" json:"last_seen"`
 }
 
+type Count struct {
+	Count int `json:"count"`
+}
+type PeerCount struct {
+	ID       string    `storm:"id" json:"id"`
+	LastSeen time.Time `storm:"index" json:"last_seen"`
+}
+
 // Member is the holder of bls and stakes
 type Member struct {
 	PublicKeyBLS []byte  `json:"bls_key"`

--- a/pkg/core/consensus/capi/model.go
+++ b/pkg/core/consensus/capi/model.go
@@ -36,9 +36,12 @@ type PeerJSON struct {
 	LastSeen time.Time `storm:"index" json:"last_seen"`
 }
 
+// Count is the struct used to return a count for a API service
 type Count struct {
 	Count int `json:"count"`
 }
+
+// PeerCount is the struct used to save a peer or remove from a PeerCount collection in the API monitoring database
 type PeerCount struct {
 	ID       string    `storm:"id" json:"id"`
 	LastSeen time.Time `storm:"index" json:"last_seen"`

--- a/pkg/p2p/peer/handshake_test.go
+++ b/pkg/p2p/peer/handshake_test.go
@@ -34,10 +34,7 @@ func TestHandshake(t *testing.T) {
 	client, srv := net.Pipe()
 
 	go func() {
-		peerReader, err := StartPeerReader(srv, eb, rpcBus, counter, nil)
-		if err != nil {
-			panic(err)
-		}
+		peerReader := StartPeerReader(srv, eb, rpcBus, counter, nil)
 
 		if err := peerReader.Accept(); err != nil {
 			panic(err)

--- a/pkg/p2p/peer/peer.go
+++ b/pkg/p2p/peer/peer.go
@@ -364,7 +364,7 @@ func (p *Reader) readLoop() {
 		// TODO: error here should be checked in order to decrease reputation
 		// or blacklist spammers
 		startTime := time.Now().UnixNano()
-		if err := p.router.Collect(message); err != nil {
+		if err = p.router.Collect(message); err != nil {
 			l.WithError(err).Error("message routing")
 		}
 
@@ -411,8 +411,6 @@ func (p *Reader) keepAliveLoop() (*time.Timer, chan struct{}) {
 					if config.Get().API.Enabled {
 						go func() {
 							addr := p.Addr()
-							err := p.Connection.keepAlive()
-
 							peerCount := capi.PeerCount{
 								ID: addr,
 							}

--- a/pkg/p2p/peer/peer_in_test.go
+++ b/pkg/p2p/peer/peer_in_test.go
@@ -55,16 +55,10 @@ func TestPingLoop(t *testing.T) {
 	writer2 := NewWriter(srv, processing.NewGossip(protocol.TestNet), bus)
 	go writer2.Serve(responseChan2, make(chan struct{}, 1))
 
-	reader, err := NewReader(client, processing.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), bus, rpcbus.New(), &chainsync.Counter{}, responseChan, make(chan struct{}, 1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	reader := NewReader(client, processing.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), bus, rpcbus.New(), &chainsync.Counter{}, responseChan, make(chan struct{}, 1))
 	go reader.ReadLoop()
 
-	reader2, err := NewReader(srv, processing.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), bus, rpcbus.New(), &chainsync.Counter{}, responseChan2, make(chan struct{}, 1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	reader2 := NewReader(srv, processing.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), bus, rpcbus.New(), &chainsync.Counter{}, responseChan2, make(chan struct{}, 1))
 	go reader2.ReadLoop()
 
 	// We should eventually get a pong message out of responseChan2
@@ -208,7 +202,7 @@ func testReader(t *testing.T) (*Reader, net.Conn, net.Conn, chan<- *bytes.Buffer
 
 	respChan := make(chan *bytes.Buffer, 10)
 	g := processing.NewGossip(protocol.TestNet)
-	peer, _ := NewReader(r, g, d, bus, rpcbus, &chainsync.Counter{},
+	peer := NewReader(r, g, d, bus, rpcbus, &chainsync.Counter{},
 		respChan, make(chan struct{}, 1))
 
 	// Run the non-recover readLoop to watch for panics

--- a/pkg/p2p/peer/peer_test.go
+++ b/pkg/p2p/peer/peer_test.go
@@ -39,10 +39,7 @@ func TestReader(t *testing.T) {
 	rpcBus := rpcbus.New()
 	counter := chainsync.NewCounter()
 
-	peerReader, err := StartPeerReader(srv, eb, rpcBus, counter, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	peerReader := StartPeerReader(srv, eb, rpcBus, counter, nil)
 
 	// Our message should come in on the agreement topic
 	agreementChan := make(chan message.Message, 1)

--- a/pkg/p2p/peer/peer_test_func.go
+++ b/pkg/p2p/peer/peer_test_func.go
@@ -15,7 +15,7 @@ import (
 // StartPeerReader creates a Peer reader for testing purposes. The reader is
 // at the receiving end of a binary-serialized Gossip notification and communicates through the
 // eventbus
-func StartPeerReader(conn net.Conn, bus *eventbus.EventBus, rpcBus *rpcbus.RPCBus, counter *chainsync.Counter, responseChan chan<- *bytes.Buffer) (*Reader, error) {
+func StartPeerReader(conn net.Conn, bus *eventbus.EventBus, rpcBus *rpcbus.RPCBus, counter *chainsync.Counter, responseChan chan<- *bytes.Buffer) *Reader {
 	dupeMap := dupemap.NewDupeMap(5)
 	exitChan := make(chan struct{}, 1)
 	return NewReader(conn, processing.NewGossip(protocol.TestNet), dupeMap, bus, rpcBus, counter, responseChan, exitChan)


### PR DESCRIPTION
Add monitoring API to count connected peers #751
Peer method NewReader returns error, but error is always nil. Return err is checked and will panic if not nil wich makes no sense since it is always nil #750

How to test it:

1. Start a local cluster with devnet.sh with 4 peers
`/devnet.sh -q 3`

2. Curl the endpoint of Node 0 and observe 3 peers connected:
```
curl http://localhost:9490/p2p/count
{"count":3}
```

3. Kill node 3
```
ps -ef|grep dusk
kill - 9 (PID OF NODE 3 HERE)
```

4. Curl the endpoint of Node 0 and observe 2 peers connected
```
curl http://localhost:9490/p2p/count
{"count":2}
```