### PR TITLE
Replace usage of exitChan for context in Peer

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -250,7 +250,7 @@ func (s *Server) OnAccept(conn net.Conn) {
 	logServer.WithField("address", peerReader.Addr()).Debugln("connection established")
 
 	peerWriter := peer.NewWriter(conn, s.gossip, s.eventBus)
-	peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
+	go peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
 }
 
 // OnConnection is the callback for writing to the peers
@@ -271,7 +271,7 @@ func (s *Server) OnConnection(conn net.Conn, addr string) {
 		log.Panic(err)
 	}
 
-	peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
+	go peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
 }
 
 // Close the chain and the connections created through the RPC bus

--- a/go.sum
+++ b/go.sum
@@ -351,16 +351,19 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96d
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0 h1:eMV1t2NQRc3r1k3guWiv/zEeqZZP6kPvpUfy6byfL1g=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -697,6 +700,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/p2p/peer/factory.go
+++ b/pkg/p2p/peer/factory.go
@@ -22,7 +22,7 @@ func NewReaderFactory(processor *MessageProcessor) *ReaderFactory {
 
 // SpawnReader returns a Reader. It will still need to be launched by
 // running ReadLoop in a goroutine.
-func (f *ReaderFactory) SpawnReader(conn net.Conn, gossip *protocol.Gossip, dupeMap *dupemap.DupeMap, responseChan chan<- bytes.Buffer, exitChan chan<- struct{}) (*Reader, error) {
+func (f *ReaderFactory) SpawnReader(conn net.Conn, gossip *protocol.Gossip, dupeMap *dupemap.DupeMap, responseChan chan<- bytes.Buffer) (*Reader, error) {
 	pconn := &Connection{
 		Conn:   conn,
 		gossip: gossip,
@@ -30,7 +30,6 @@ func (f *ReaderFactory) SpawnReader(conn net.Conn, gossip *protocol.Gossip, dupe
 
 	reader := &Reader{
 		Connection:   pconn,
-		exitChan:     exitChan,
 		responseChan: responseChan,
 		processor:    f.processor,
 	}

--- a/pkg/p2p/peer/handshake_test.go
+++ b/pkg/p2p/peer/handshake_test.go
@@ -34,8 +34,7 @@ func TestHandshake(t *testing.T) {
 
 	go func() {
 		responseChan := make(chan bytes.Buffer, 100)
-		exitChan := make(chan struct{}, 1)
-		peerReader, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan, exitChan)
+		peerReader, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/p2p/peer/peer_in_test.go
+++ b/pkg/p2p/peer/peer_in_test.go
@@ -67,8 +67,8 @@ func TestPingLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Create(context.Background(), reader, writer, responseChan)
-	Create(context.Background(), reader2, writer2, responseChan2)
+	go Create(context.Background(), reader, writer, responseChan)
+	go Create(context.Background(), reader2, writer2, responseChan2)
 
 	// We should eventually get a pong message out of responseChan2
 	for {
@@ -230,7 +230,7 @@ func testReader(t *testing.T, f *ReaderFactory) (*Reader, net.Conn, net.Conn, ch
 	peer, _ := f.SpawnReader(r, g, d, respChan)
 
 	// Run the non-recover readLoop to watch for panics
-	go assert.NotPanics(t, func() { peer.readLoop(context.Background()) })
+	go assert.NotPanics(t, func() { peer.readLoop(context.Background(), make(chan error, 1)) })
 
 	time.Sleep(200 * time.Millisecond)
 

--- a/pkg/p2p/peer/peer_in_test.go
+++ b/pkg/p2p/peer/peer_in_test.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"os"
 	"testing"
@@ -46,29 +47,28 @@ func TestPingLoop(t *testing.T) {
 
 	responseChan := make(chan bytes.Buffer, 10)
 	writer := NewWriter(client, protocol.NewGossip(protocol.TestNet), bus)
-	go writer.Serve(responseChan, make(chan struct{}, 1))
 
 	// Set up the other end of the exchange
 	responseChan2 := make(chan bytes.Buffer, 10)
 	writer2 := NewWriter(srv, protocol.NewGossip(protocol.TestNet), bus)
-	go writer2.Serve(responseChan2, make(chan struct{}, 1))
 
 	// Set up reader factory
 	processor := NewMessageProcessor(bus)
 	processor.Register(topics.Ping, responding.ProcessPing)
 	factory := NewReaderFactory(processor)
 
-	reader, err := factory.SpawnReader(client, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan, make(chan struct{}, 1))
+	reader, err := factory.SpawnReader(client, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan)
 	if err != nil {
 		t.Fatal(err)
 	}
-	go reader.ReadLoop()
 
-	reader2, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan2, make(chan struct{}, 1))
+	reader2, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	go reader2.ReadLoop()
+
+	Create(context.Background(), reader, writer, responseChan)
+	Create(context.Background(), reader2, writer2, responseChan2)
 
 	// We should eventually get a pong message out of responseChan2
 	for {
@@ -227,10 +227,10 @@ func testReader(t *testing.T, f *ReaderFactory) (*Reader, net.Conn, net.Conn, ch
 
 	respChan := make(chan bytes.Buffer, 10)
 	g := protocol.NewGossip(protocol.TestNet)
-	peer, _ := f.SpawnReader(r, g, d, respChan, make(chan struct{}, 1))
+	peer, _ := f.SpawnReader(r, g, d, respChan)
 
 	// Run the non-recover readLoop to watch for panics
-	go assert.NotPanics(t, peer.readLoop)
+	go assert.NotPanics(t, func() { peer.readLoop(context.Background()) })
 
 	time.Sleep(200 * time.Millisecond)
 

--- a/pkg/p2p/peer/peer_test.go
+++ b/pkg/p2p/peer/peer_test.go
@@ -54,7 +54,7 @@ func TestReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go peerReader.ReadLoop(context.Background(), func() {})
+	go peerReader.ReadLoop(context.Background(), make(chan error, 1))
 
 	errChan := make(chan error, 1)
 	go func(eChan chan error) {
@@ -110,7 +110,7 @@ func TestWriteLoop(t *testing.T) {
 	go func(g *protocol.Gossip) {
 		responseChan := make(chan bytes.Buffer)
 		writer := NewWriter(client, g, bus, 30*time.Millisecond)
-		go writer.Serve(context.Background(), func() {}, responseChan)
+		go writer.Serve(context.Background(), responseChan, make(chan error, 1))
 
 		bufCopy := buf
 		responseChan <- bufCopy

--- a/pkg/p2p/peer/peer_test.go
+++ b/pkg/p2p/peer/peer_test.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net"
 	"testing"
@@ -48,13 +49,12 @@ func TestReader(t *testing.T) {
 
 	dupeMap := dupemap.NewDupeMap(5)
 	responseChan := make(chan bytes.Buffer, 100)
-	exitChan := make(chan struct{}, 1)
-	peerReader, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupeMap, responseChan, exitChan)
+	peerReader, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupeMap, responseChan)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	go peerReader.ReadLoop()
+	go peerReader.ReadLoop(context.Background(), func() {})
 
 	errChan := make(chan error, 1)
 	go func(eChan chan error) {
@@ -110,7 +110,7 @@ func TestWriteLoop(t *testing.T) {
 	go func(g *protocol.Gossip) {
 		responseChan := make(chan bytes.Buffer)
 		writer := NewWriter(client, g, bus, 30*time.Millisecond)
-		go writer.Serve(responseChan, make(chan struct{}, 1))
+		go writer.Serve(context.Background(), func() {}, responseChan)
 
 		bufCopy := buf
 		responseChan <- bufCopy


### PR DESCRIPTION
This allows either goroutine to cancel the other
on an encountered error. This gives way
to more idiomatic management of these goroutines.

Fixes #761