### PR TITLE
Remove error return value from SpawnReader

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -238,11 +238,7 @@ func Setup() *Server {
 // OnAccept read incoming packet from the peers
 func (s *Server) OnAccept(conn net.Conn) {
 	writeQueueChan := make(chan bytes.Buffer, 1000)
-	peerReader, err := s.readerFactory.SpawnReader(conn, s.gossip, s.dupeMap, writeQueueChan)
-	if err != nil {
-		panic(err)
-	}
-
+	peerReader := s.readerFactory.SpawnReader(conn, s.gossip, s.dupeMap, writeQueueChan)
 	if err := peerReader.Accept(); err != nil {
 		logServer.WithError(err).Warnln("OnAccept, problem performing handshake")
 		return
@@ -266,10 +262,7 @@ func (s *Server) OnConnection(conn net.Conn, addr string) {
 	logServer.WithField("address", address).
 		Debugln("connection established")
 
-	peerReader, err := s.readerFactory.SpawnReader(conn, s.gossip, s.dupeMap, writeQueueChan)
-	if err != nil {
-		log.Panic(err)
-	}
+	peerReader := s.readerFactory.SpawnReader(conn, s.gossip, s.dupeMap, writeQueueChan)
 
 	go peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
 }

--- a/pkg/p2p/peer/factory.go
+++ b/pkg/p2p/peer/factory.go
@@ -22,7 +22,7 @@ func NewReaderFactory(processor *MessageProcessor) *ReaderFactory {
 
 // SpawnReader returns a Reader. It will still need to be launched by
 // running ReadLoop in a goroutine.
-func (f *ReaderFactory) SpawnReader(conn net.Conn, gossip *protocol.Gossip, dupeMap *dupemap.DupeMap, responseChan chan<- bytes.Buffer) (*Reader, error) {
+func (f *ReaderFactory) SpawnReader(conn net.Conn, gossip *protocol.Gossip, dupeMap *dupemap.DupeMap, responseChan chan<- bytes.Buffer) *Reader {
 	pconn := &Connection{
 		Conn:   conn,
 		gossip: gossip,
@@ -40,5 +40,5 @@ func (f *ReaderFactory) SpawnReader(conn net.Conn, gossip *protocol.Gossip, dupe
 		responseChan <- topics.MemPool.ToBuffer()
 	}()
 
-	return reader, nil
+	return reader
 }

--- a/pkg/p2p/peer/handshake_test.go
+++ b/pkg/p2p/peer/handshake_test.go
@@ -34,11 +34,7 @@ func TestHandshake(t *testing.T) {
 
 	go func() {
 		responseChan := make(chan bytes.Buffer, 100)
-		peerReader, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan)
-		if err != nil {
-			panic(err)
-		}
-
+		peerReader := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan)
 		if err := peerReader.Accept(); err != nil {
 			panic(err)
 		}

--- a/pkg/p2p/peer/peer_in_test.go
+++ b/pkg/p2p/peer/peer_in_test.go
@@ -57,15 +57,9 @@ func TestPingLoop(t *testing.T) {
 	processor.Register(topics.Ping, responding.ProcessPing)
 	factory := NewReaderFactory(processor)
 
-	reader, err := factory.SpawnReader(client, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan)
-	if err != nil {
-		t.Fatal(err)
-	}
+	reader := factory.SpawnReader(client, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan)
 
-	reader2, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	reader2 := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupemap.NewDupeMap(0), responseChan2)
 
 	go Create(context.Background(), reader, writer, responseChan)
 	go Create(context.Background(), reader2, writer2, responseChan2)
@@ -227,7 +221,7 @@ func testReader(t *testing.T, f *ReaderFactory) (*Reader, net.Conn, net.Conn, ch
 
 	respChan := make(chan bytes.Buffer, 10)
 	g := protocol.NewGossip(protocol.TestNet)
-	peer, _ := f.SpawnReader(r, g, d, respChan)
+	peer := f.SpawnReader(r, g, d, respChan)
 
 	// Run the non-recover readLoop to watch for panics
 	go assert.NotPanics(t, func() { peer.readLoop(context.Background(), make(chan error, 1)) })

--- a/pkg/p2p/peer/peer_test.go
+++ b/pkg/p2p/peer/peer_test.go
@@ -49,10 +49,7 @@ func TestReader(t *testing.T) {
 
 	dupeMap := dupemap.NewDupeMap(5)
 	responseChan := make(chan bytes.Buffer, 100)
-	peerReader, err := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupeMap, responseChan)
-	if err != nil {
-		t.Fatal(err)
-	}
+	peerReader := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), dupeMap, responseChan)
 
 	go peerReader.ReadLoop(context.Background(), make(chan error, 1))
 


### PR DESCRIPTION
This value would always be nil, and thus is unnecessary.

Fixes #750