### PR TITLE
Add a case for reading password from a non-terminal stdin

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -272,7 +272,7 @@ start_dusk_func() {
   DDIR="${currentDir}/devnet/dusk_data/dusk${i}"
 
   CMD="${currentDir}/bin/dusk --config ${DDIR}/dusk.toml"
-  ${CMD} >> "${currentDir}/devnet/dusk_data/logs/dusk$i.log" 2> "${currentDir}/devnet/dusk_data/logs/dusk$i.err" &
+  ${CMD} <<< "password" >> "${currentDir}/devnet/dusk_data/logs/dusk$i.log" 2> "${currentDir}/devnet/dusk_data/logs/dusk$i.err" &
 
   EXEC_PID=$!
   echo "started Dusk node $i, pid=$EXEC_PID"


### PR DESCRIPTION
Fixes #799 