### PR TITLE
Start consensus only after all nodes have been initialized

### DIFF
--- a/pkg/core/consensus/testing/consensus_test.go
+++ b/pkg/core/consensus/testing/consensus_test.go
@@ -67,6 +67,15 @@ func TestConsensus(t *testing.T) {
 		defer cancelNode()
 	}
 
+	// Start the consensus loop on all nodes
+	for _, n := range nodes {
+		go func(n *node) {
+			if err := n.chain.ProduceBlock(); err != nil && err != context.Canceled {
+				panic(err)
+			}
+		}(n)
+	}
+
 	// To follow consensus properly, we should see accepted blocks coming in
 	// from each node.
 	// Let's make sure the consensus can survive for at least up to 10 rounds.

--- a/pkg/core/consensus/testing/node.go
+++ b/pkg/core/consensus/testing/node.go
@@ -63,12 +63,6 @@ func newNode(ctx context.Context, assert *assert.Assertions, eb *eventbus.EventB
 
 	c, err := chain.New(ctx, db, eb, rb, l, l, nil, proxy, lp)
 	assert.NoError(err)
-	go func() {
-		if err := c.ProduceBlock(); err != nil && err != context.Canceled {
-			panic(err)
-		}
-	}()
-
 	return &node{chain: c}
 }
 


### PR DESCRIPTION
This fixes a bug, where some nodes would not
receive all messages properly, and cause TestConsensus to fail
over a panic when attempting to retrieve a candidate block
from the network. The panic occurs because there are no
CandidateBrokers initialized in this test, and thus the request
message falls on deaf ears. The upward propagation of the error
ultimately leads to a panic.

Fixes #866