### PR TITLE
Implement node.ConfigService

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -166,6 +166,8 @@ func Setup() *Server {
 		log.Panic(err)
 	}
 
+	_ = newConfigService(grpcServer)
+
 	eventBus := eventbus.New()
 	rpcBus := rpcbus.New()
 

--- a/cmd/dusk/setconfig.go
+++ b/cmd/dusk/setconfig.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this
+// file, you can obtain one at https://opensource.org/licenses/MIT.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+package main
+
+import (
+	"context"
+
+	"github.com/dusk-network/dusk-protobuf/autogen/go/node"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// configService implements handlers for node.ConfigService calls.
+// The service is about modifying specific config settings in runtime.
+// supported configs: logger.level.
+type configService struct {
+}
+
+func newConfigService(srv *grpc.Server) *configService {
+	cs := new(configService)
+
+	if srv != nil {
+		node.RegisterConfigServer(srv, cs)
+	}
+	return cs
+}
+
+func (cs *configService) ChangeLogLevel(ctx context.Context, c *node.LogLevelRequest) (*node.GenericResponse, error) {
+	level, err := logrus.ParseLevel(c.Level)
+	if err == nil {
+		logrus.SetLevel(level)
+	}
+	return &node.GenericResponse{}, err
+}

--- a/cmd/utils/grpcclient/client.go
+++ b/cmd/utils/grpcclient/client.go
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this
+// file, you can obtain one at https://opensource.org/licenses/MIT.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+package grpcclient
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// grpcClient is a helper for establishing grpc client connection reusing
+// default RPCConfiguration struct. TODO: It seems similar impl already used in
+// wallet pkg and test harness. Refactor this by providing a single client.
+type grpcClient struct {
+	dialTimeout int64
+	conn        *grpc.ClientConn
+}
+
+// TryConnect initializes a grpcClient to dusk-blockchain node grpc interface.
+// For over-tcp communication, it could enable TLS and Basic Authentication.
+func (c *grpcClient) TryConnect(addr string) error {
+	dialOptions := make([]grpc.DialOption, 0)
+	dialOptions = append(dialOptions, grpc.WithBlock())
+	dialOptions = append(dialOptions, grpc.WithInsecure())
+
+	// Init dial timeout
+	var dialCtx context.Context
+
+	if c.dialTimeout > 0 {
+		var cancel context.CancelFunc
+
+		dialCtx, cancel = context.WithTimeout(context.Background(),
+			time.Duration(c.dialTimeout)*time.Second)
+		defer cancel()
+	}
+
+	// Set up a connection to the server.
+	conn, err := grpc.DialContext(dialCtx, addr, dialOptions...)
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+	return nil
+}
+
+// Close conn.
+func (c *grpcClient) Close() {
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+}

--- a/cmd/utils/grpcclient/configservice.go
+++ b/cmd/utils/grpcclient/configservice.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this
+// file, you can obtain one at https://opensource.org/licenses/MIT.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+package grpcclient
+
+import (
+	"context"
+	"time"
+
+	node "github.com/dusk-network/dusk-protobuf/autogen/go/node"
+
+	"google.golang.org/grpc"
+)
+
+// SetConfigReq describes a set-config request.
+type SetConfigReq struct {
+	Host string
+
+	Name     string
+	NewValue string
+}
+
+// SetConfig implement a cli client over node.ConfigClient grpc interface.
+func SetConfig(r SetConfigReq) error {
+	// TODO: enable tcp transport
+	addr := "unix://" + r.Host
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	client := node.NewConfigClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if r.Name == "logger.level" {
+		_, err = client.ChangeLogLevel(ctx, &node.LogLevelRequest{Level: r.NewValue})
+	}
+
+	return err
+}

--- a/cmd/utils/main.go
+++ b/cmd/utils/main.go
@@ -42,9 +42,9 @@ func main() {
 }
 
 var (
-	grpcHostFlag = cli.StringFlag{
-		Name:  "grpchost",
-		Usage: "gRPC HOST , eg: --grpchost=127.0.0.1:9001",
+	grpcAddressFlag = cli.StringFlag{
+		Name:  "grpcaddr",
+		Usage: "gRPC UNIX or TCP address , eg: --grpcaddr=127.0.0.1:9001 or --grpcaddr=unix:///var/dusk-grpc.sock",
 		Value: "127.0.0.1:9001",
 	}
 
@@ -173,7 +173,7 @@ var (
 		ArgsUsage: "",
 		Flags: []cli.Flag{
 			txtypeFlag,
-			grpcHostFlag,
+			grpcAddressFlag,
 			amountFlag,
 			lockTimeFlag,
 			addressFlag,
@@ -206,13 +206,16 @@ var (
 		Description: `Execute/Query transactions for a Dusk node`,
 	}
 
+	// setconfig command
+	// Example ./bin/utils setconfig --grpcaddr="unix:///tmp/dusk-node/dusk-grpc.sock" --configname="logger.level" --configvalue="info".
+	// 	     ./bin/utils setconfig --grpcaddr="127.0.0.1:10506" --configname="logger.level" --configvalue="trace".
 	setConfigCMD = cli.Command{
 		Name:      "setconfig",
 		Usage:     "set config in run-time",
 		Action:    setConfigAction,
 		ArgsUsage: "",
 		Flags: []cli.Flag{
-			grpcHostFlag,
+			grpcAddressFlag,
 			configNameFlag,
 			configValueFlag,
 		},
@@ -235,7 +238,7 @@ func metricsAction(ctx *cli.Context) error {
 
 // transactionsAction will expose the metrics endpoint.
 func transactionsAction(ctx *cli.Context) error {
-	grpcHost := ctx.String(grpcHostFlag.Name)
+	grpcHost := ctx.String(grpcAddressFlag.Name)
 	amount := ctx.Uint64(amountFlag.Name)
 	lockTime := ctx.Uint64(lockTimeFlag.Name)
 	txtype := ctx.String(txtypeFlag.Name)
@@ -284,9 +287,11 @@ func mockRuskAction(ctx *cli.Context) error {
 }
 
 func setConfigAction(ctx *cli.Context) error {
-	return grpcclient.SetConfig(grpcclient.SetConfigReq{
+	req := grpcclient.SetConfigReq{
 		Name:     ctx.String(configNameFlag.Name),
 		NewValue: ctx.String(configValueFlag.Name),
-		Host:     ctx.String(grpcHostFlag.Name),
-	})
+	}
+
+	req.Address = ctx.String(grpcAddressFlag.Name)
+	return grpcclient.TrySetConfig(req)
 }

--- a/cmd/utils/main.go
+++ b/cmd/utils/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dusk-network/dusk-blockchain/cmd/utils/grpcclient"
 	"github.com/dusk-network/dusk-blockchain/cmd/utils/mock"
 
 	"github.com/dusk-network/dusk-blockchain/cmd/utils/transactions"
@@ -31,6 +32,7 @@ func main() {
 		transactionsCMD,
 		mockCMD,
 		mockRUSKCMD,
+		setConfigCMD,
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -137,6 +139,18 @@ var (
 		Value: "password",
 	}
 
+	configNameFlag = cli.StringFlag{
+		Name:  "configname",
+		Usage: "Config ID from dusk.toml, eg: logger.level",
+		Value: "",
+	}
+
+	configValueFlag = cli.StringFlag{
+		Name:  "configvalue",
+		Usage: "New Config value, eg: info",
+		Value: "",
+	}
+
 	metricsCMD = cli.Command{
 		Name:      "metrics",
 		Usage:     "expose a metrics endpoint",
@@ -190,6 +204,19 @@ var (
 			walletFileFlag,
 		},
 		Description: `Execute/Query transactions for a Dusk node`,
+	}
+
+	setConfigCMD = cli.Command{
+		Name:      "setconfig",
+		Usage:     "set config in run-time",
+		Action:    setConfigAction,
+		ArgsUsage: "",
+		Flags: []cli.Flag{
+			grpcHostFlag,
+			configNameFlag,
+			configValueFlag,
+		},
+		Description: `Modify a specific dusk config in run-time`,
 	}
 )
 
@@ -254,4 +281,12 @@ func mockRuskAction(ctx *cli.Context) error {
 
 	err := mock.RunRUSKMock(ruskNetwork, ruskAddress, walletStore, walletFile)
 	return err
+}
+
+func setConfigAction(ctx *cli.Context) error {
+	return grpcclient.SetConfig(grpcclient.SetConfigReq{
+		Name:     ctx.String(configNameFlag.Name),
+		NewValue: ctx.String(configValueFlag.Name),
+		Host:     ctx.String(grpcHostFlag.Name),
+	})
 }

--- a/cmd/utils/tps.sh
+++ b/cmd/utils/tps.sh
@@ -33,7 +33,7 @@ set -euxo pipefail
 
 sendtx_func() {
   echo "sending transactions to node $i ..."
-  "$PWD"/bin/utils transactions --txtype=transfer --amount=1 --locktime=1 --grpchost=unix:///tmp/localnet-"${ID}"/node-$((PORT + i))/dusk-grpc.sock > /tmp/localnet-"${ID}"/tps.log 2>&1 & disown
+  "$PWD"/bin/utils transactions --txtype=transfer --amount=1 --locktime=1 --grpcaddr=unix:///tmp/localnet-"${ID}"/node-$((PORT + i))/dusk-grpc.sock > /tmp/localnet-"${ID}"/tps.log 2>&1 & disown
 
   TX_PID=$!
   echo "sent transaction to node, pid=$TX_PID"

--- a/devnet.sh
+++ b/devnet.sh
@@ -279,7 +279,7 @@ start_dusk_func() {
   sleep 1
 
   # load wallet cmd
-  LOADWALLET_CMD="./bin/utils walletutils --grpchost unix://${DDIR}/dusk-grpc.sock --walletcmd loadwallet --walletpassword password"
+  LOADWALLET_CMD="./bin/utils walletutils --grpcaddr unix://${DDIR}/dusk-grpc.sock --walletcmd loadwallet --walletpassword password"
   ${LOADWALLET_CMD} >> "${currentDir}/devnet/dusk_data/logs/load_wallet$i.log" 2>&1 &
 
 }
@@ -299,7 +299,7 @@ send_bid_func(){
   echo "Sending bid to node $i ..."
 
   # send bid cmd
-  SENDBID_CMD="./bin/utils transactions --grpchost unix://${DDIR}/dusk-grpc.sock --txtype consensus --amount 10 --locktime 10"
+  SENDBID_CMD="./bin/utils transactions --grpcaddr unix://${DDIR}/dusk-grpc.sock --txtype consensus --amount 10 --locktime 10"
   ${SENDBID_CMD} >> "${currentDir}/devnet/dusk_data/logs/sendbid_bid$i.log" 2>&1 &
 }
 

--- a/docs/elk.md
+++ b/docs/elk.md
@@ -43,7 +43,7 @@ make build && ./bin/utils metrics
 
 6. Send some txs to node 0
 ```
-make build && watch "./bin/utils transactions --txtype=transfer --amount=1 --locktime=1 --grpchost=unix://$GOPATH/src/github.com/dusk-network/dusk-blockchain/devnet/dusk_data/dusk0/dusk-grpc.sock"
+make build && watch "./bin/utils transactions --txtype=transfer --amount=1 --locktime=1 --grpcaddr=unix://$GOPATH/src/github.com/dusk-network/dusk-blockchain/devnet/dusk_data/dusk0/dusk-grpc.sock"
 ```
 ## Cleanup
 To Remove the docker with:

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/dusk-network/dusk-blockchain
 require (
 	github.com/asdine/storm/v3 v3.2.1
 	github.com/bwesterb/go-ristretto v1.1.0
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/drewolson/testflight v1.0.0
 	github.com/dusk-network/dusk-crypto v0.1.3
-	github.com/dusk-network/dusk-protobuf v0.2.15
+	github.com/dusk-network/dusk-protobuf v0.2.16
 	github.com/dusk-network/dusk-wallet/v2 v2.0.3
 	github.com/dusk-network/dusk-zkproof v0.0.0-20190727103229-8b0c008561ee
 	github.com/etherlabsio/healthcheck v0.0.0-20191224061800-dd3d2fd8c3f6
@@ -20,7 +21,7 @@ require (
 	github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/go-chi/render v1.0.1
-	github.com/golangci/golangci-lint v1.31.0 // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/gofountain v0.0.0-20160820054803-4928733085e9
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.4
@@ -28,9 +29,13 @@ require (
 	github.com/gorilla/rpc v1.2.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/graphql-go/graphql v0.7.8
+	github.com/kr/text v0.2.0 // indirect
 	github.com/machinebox/graphql v0.2.2
 	github.com/manifoldco/promptui v0.7.0
 	github.com/matryer/is v1.2.0 // indirect
+	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/onsi/ginkgo v1.13.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1
@@ -45,7 +50,11 @@ require (
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/urfave/cli v1.22.3
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
+	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/grpc v1.29.0
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )
 
 go 1.13

--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -333,7 +333,7 @@ func (m *Mempool) onIdle() {
 			Warn("exceeding max size")
 	}
 
-	if log.Logger.Level == logger.TraceLevel {
+	if log.Logger.GetLevel() == logger.TraceLevel {
 		if m.verified.Len() > 0 {
 			_ = m.verified.Range(func(k txHash, t TxDesc) error {
 				log.WithField("txid", toHex(k[:])).Trace("accepted transaction")


### PR DESCRIPTION
fixes #964 

Example usage:
```
./bin/utils setconfig --grpcaddr="unix:///tmp/dusk-node/dusk-grpc.sock" --configname="logger.level" --configvalue="info"

./bin/utils setconfig --grpcaddr="127.0.0.1:10506" --configname="logger.level" --configvalue="trace"
```