### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/pkg/p2p/wire/protocol/protocol.go
+++ b/pkg/p2p/wire/protocol/protocol.go
@@ -32,8 +32,8 @@ const (
 // NodeVer is the current node version.
 var NodeVer = &Version{
 	Major: 0,
-	Minor: 3,
-	Patch: 0,
+	Minor: 4,
+	Patch: 1,
 }
 
 // Magic is the network that Dusk is running on.


### PR DESCRIPTION
This was missed previously for the release of 0.4.0, hence
why it was changed from 0.3.0 instead

Fixes #987