### PR TITLE
Remove potential panic on closed channel send when connection drops

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -307,14 +307,7 @@ func (s *Server) OnAccept(conn net.Conn) {
 	logServer.WithField("address", peerReader.Addr()).Debugln("connection established")
 
 	peerWriter := peer.NewWriter(conn, s.gossip, s.eventBus)
-
-	go func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		err := peer.Create(ctx, peerReader, peerWriter, writeQueueChan)
-		logServer.WithError(err).Warnln("error received from peer")
-	}()
+	go peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
 }
 
 // OnConnection is the callback for writing to the peers.
@@ -333,14 +326,7 @@ func (s *Server) OnConnection(conn net.Conn, addr string) {
 		Debugln("connection established")
 
 	peerReader := s.readerFactory.SpawnReader(conn, s.gossip, writeQueueChan)
-
-	go func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		err := peer.Create(ctx, peerReader, peerWriter, writeQueueChan)
-		logServer.WithError(err).Warnln("error received from peer")
-	}()
+	go peer.Create(context.Background(), peerReader, peerWriter, writeQueueChan)
 }
 
 // Close the chain and the connections created through the RPC bus.

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,7 @@ github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=

--- a/pkg/p2p/peer/peer.go
+++ b/pkg/p2p/peer/peer.go
@@ -191,9 +191,9 @@ func (p *Reader) Accept() error {
 	return nil
 }
 
-// Create two-way communication with a peer. This function will allow both
-// goroutines to run as long as no errors are encountered. Once the first error
-// comes through, the context is canceled, and both goroutines are cleaned up.
+// Create two-way communication with a peer. The function creates a shared context
+// between both goroutines, which allows one to cancel the other in case of a
+// fatal error being encountered.
 func Create(ctx context.Context, reader *Reader, writer *Writer, writeQueueChan <-chan bytes.Buffer) {
 	pCtx, cancel := context.WithCancel(ctx)
 

--- a/pkg/p2p/peer/peer.go
+++ b/pkg/p2p/peer/peer.go
@@ -194,27 +194,22 @@ func (p *Reader) Accept() error {
 // Create two-way communication with a peer. This function will allow both
 // goroutines to run as long as no errors are encountered. Once the first error
 // comes through, the context is canceled, and both goroutines are cleaned up.
-func Create(ctx context.Context, reader *Reader, writer *Writer, writeQueueChan <-chan bytes.Buffer) error {
-	errChan := make(chan error, 1)
-	defer close(errChan)
+func Create(ctx context.Context, reader *Reader, writer *Writer, writeQueueChan <-chan bytes.Buffer) {
+	pCtx, cancel := context.WithCancel(ctx)
 
-	go reader.ReadLoop(ctx, errChan)
-	go writer.Serve(ctx, writeQueueChan, errChan)
+	go func() {
+		reader.ReadLoop(pCtx)
+		cancel()
+	}()
 
-	return <-errChan
-}
-
-// This attempts a non-blocking send to the errChan, which prevents panics
-// from sending to a closed channel.
-func sendError(errChan chan error, err error) {
-	select {
-	case errChan <- err:
-	default:
-	}
+	go func() {
+		writer.Serve(ctx, writeQueueChan)
+		cancel()
+	}()
 }
 
 // Serve utilizes two different methods for writing to the open connection.
-func (w *Writer) Serve(ctx context.Context, writeQueueChan <-chan bytes.Buffer, errChan chan error) {
+func (w *Writer) Serve(ctx context.Context, writeQueueChan <-chan bytes.Buffer) {
 	// Any gossip topics are written into interrupt-driven ringBuffer
 	// Single-consumer pushes messages to the socket
 	g := &GossipConnector{w.gossip, w.Connection}
@@ -222,7 +217,7 @@ func (w *Writer) Serve(ctx context.Context, writeQueueChan <-chan bytes.Buffer, 
 
 	// writeQueue - FIFO queue
 	// writeLoop pushes first-in message to the socket
-	w.writeLoop(ctx, writeQueueChan, errChan)
+	w.writeLoop(ctx, writeQueueChan)
 	w.onDisconnect()
 }
 
@@ -262,7 +257,7 @@ func (w *Writer) onDisconnect() {
 	}
 }
 
-func (w *Writer) writeLoop(ctx context.Context, writeQueueChan <-chan bytes.Buffer, errChan chan error) {
+func (w *Writer) writeLoop(ctx context.Context, writeQueueChan <-chan bytes.Buffer) {
 	defer func() {
 		if config.Get().API.Enabled {
 			go func() {
@@ -292,8 +287,6 @@ func (w *Writer) writeLoop(ctx context.Context, writeQueueChan <-chan bytes.Buff
 
 			if _, err := w.Connection.Write(buf.Bytes()); err != nil {
 				l.WithField("process", "writeloop").WithError(err).Warnln("error writing message")
-				sendError(errChan, err)
-
 				return
 			}
 		case <-ctx.Done():
@@ -306,7 +299,7 @@ func (w *Writer) writeLoop(ctx context.Context, writeQueueChan <-chan bytes.Buff
 // ReadLoop will block on the read until a message is read, or until the deadline
 // is reached. Should be called in a go-routine, after a successful handshake with
 // a peer. Eventual duplicated messages are silently discarded.
-func (p *Reader) ReadLoop(ctx context.Context, errChan chan error) {
+func (p *Reader) ReadLoop(ctx context.Context) {
 	// As the peer ReadLoop is at the front-line of P2P network, receiving a
 	// malformed frame by an adversary node could lead to a panic.
 	// In such situation, the node should survive but adversary conn gets dropped
@@ -315,10 +308,10 @@ func (p *Reader) ReadLoop(ctx context.Context, errChan chan error) {
 	// 		log.Errorf("Peer %s failed with critical issue: %v", p.RemoteAddr(), r)
 	// 	}
 	// }()
-	p.readLoop(ctx, errChan)
+	p.readLoop(ctx)
 }
 
-func (p *Reader) readLoop(ctx context.Context, errChan chan error) {
+func (p *Reader) readLoop(ctx context.Context) {
 	defer func() {
 		_ = p.Conn.Close()
 	}()
@@ -344,27 +337,23 @@ func (p *Reader) readLoop(ctx context.Context, errChan chan error) {
 		err := p.Conn.SetReadDeadline(time.Now().Add(readWriteTimeout))
 		if err != nil {
 			l.WithError(err).Warnf("error setting read timeout")
-			sendError(errChan, err)
 			return
 		}
 
 		b, err := p.gossip.ReadMessage(p.Conn)
 		if err != nil {
 			l.WithError(err).Warnln("error reading message")
-			sendError(errChan, err)
 			return
 		}
 
 		message, cs, err := checksum.Extract(b)
 		if err != nil {
 			l.WithError(err).Warnln("error reading Extract message")
-			sendError(errChan, err)
 			return
 		}
 
 		if !checksum.Verify(message, cs) {
 			l.WithError(errors.New("invalid checksum")).Warnln("error reading message")
-			sendError(errChan, err)
 			return
 		}
 

--- a/pkg/p2p/peer/peer_in_test.go
+++ b/pkg/p2p/peer/peer_in_test.go
@@ -229,7 +229,7 @@ func testReader(t *testing.T, f *ReaderFactory) (*Reader, net.Conn, net.Conn, ch
 	peer := f.SpawnReader(r, g, respChan)
 
 	// Run the non-recover readLoop to watch for panics
-	go assert.NotPanics(t, func() { peer.readLoop(context.Background(), make(chan error, 1)) })
+	go assert.NotPanics(t, func() { peer.readLoop(context.Background()) })
 
 	time.Sleep(200 * time.Millisecond)
 

--- a/pkg/p2p/peer/peer_test.go
+++ b/pkg/p2p/peer/peer_test.go
@@ -55,7 +55,7 @@ func TestReader(t *testing.T) {
 	responseChan := make(chan bytes.Buffer, 100)
 	peerReader := factory.SpawnReader(srv, protocol.NewGossip(protocol.TestNet), responseChan)
 
-	go peerReader.ReadLoop(context.Background(), make(chan error, 1))
+	go peerReader.ReadLoop(context.Background())
 
 	errChan := make(chan error, 1)
 	go func(eChan chan error) {
@@ -116,7 +116,7 @@ func TestWriteLoop(t *testing.T) {
 		responseChan := make(chan bytes.Buffer)
 
 		writer := NewWriter(client, g, bus, 30*time.Millisecond)
-		go writer.Serve(context.Background(), responseChan, make(chan error, 1))
+		go writer.Serve(context.Background(), responseChan)
 
 		bufCopy := buf
 		responseChan <- bufCopy


### PR DESCRIPTION
This is achieved by fully removing the errChan
and substituting it for another Context object, created
when the peer is started up. The cancellation of one
of the loops will cascade a cancellation in the other,
without any risk of panicking.

Fixes #1020