### PR TITLE
Add UNIX prefix to TPS util address in case we're using UNIX sockets

### DIFF
--- a/cmd/utils/tps/tps.go
+++ b/cmd/utils/tps/tps.go
@@ -9,6 +9,7 @@ package tps
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/dusk-network/dusk-protobuf/autogen/go/node"
@@ -27,6 +28,10 @@ const (
 func StartSpamming(addr string, delay int, amount uint64) error {
 	if addr == "" {
 		return errors.New("no GRPC address provided")
+	}
+
+	if strings.Contains(addr, ".sock") {
+		addr = "unix://" + addr
 	}
 
 	if amount == 0 {

--- a/cmd/utils/tps/tps.go
+++ b/cmd/utils/tps/tps.go
@@ -30,6 +30,7 @@ func StartSpamming(addr string, delay int, amount uint64) error {
 		return errors.New("no GRPC address provided")
 	}
 
+	// Add UNIX prefix in case we're using unix sockets.
 	if strings.Contains(addr, ".sock") {
 		addr = "unix://" + addr
 	}

--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -265,6 +265,7 @@ func (m *Mempool) removeAccepted(b block.Block) {
 		WithField("height", b.Header.Height).
 		WithField("hash", blockHash).
 		WithField("len_txs", len(b.Txs)).
+		WithField("mempool_size", float32(m.verified.Size())/1000).
 		Info("process an accepted block")
 
 	if m.verified.Len() == 0 {
@@ -280,6 +281,7 @@ func (m *Mempool) removeAccepted(b block.Block) {
 				WithField("height", b.Header.Height).
 				WithField("hash", blockHash).
 				WithField("len_txs", len(b.Txs)).
+				WithField("mempool_size", float32(m.verified.Size())/1000).
 				Panic("could not calculate tx hash")
 		}
 
@@ -290,6 +292,7 @@ func (m *Mempool) removeAccepted(b block.Block) {
 		WithField("height", b.Header.Height).
 		WithField("hash", blockHash).
 		WithField("len_txs", len(b.Txs)).
+		WithField("mempool_size", float32(m.verified.Size())/1000).
 		Info("processing_block_completed")
 }
 


### PR DESCRIPTION
This PR also adds logging entries in the mempool which show the size of the mempool before and after processing blocks.

Fixes #940 