### PR TITLE
#1050 - add response to automaton requests

### DIFF
--- a/pkg/core/consensus/bidautomaton/bidautomaton.go
+++ b/pkg/core/consensus/bidautomaton/bidautomaton.go
@@ -93,7 +93,7 @@ func (m *BidAutomaton) sendBid() error {
 	l.WithFields(log.Fields{
 		"amount":   amount,
 		"locktime": lockTime,
-	}).Tracef("Sending bid tx")
+	}).Trace("Sending bid tx")
 
 	req := &node.BidRequest{
 		Amount:   amount,
@@ -103,6 +103,11 @@ func (m *BidAutomaton) sendBid() error {
 	timeoutSendBidTX := time.Duration(config.Get().Timeout.TimeoutSendBidTX) * time.Second
 	_, err := m.rpcBus.Call(topics.SendBidTx, rpcbus.NewRequest(req), timeoutSendBidTX)
 	if err != nil {
+		l.WithFields(log.Fields{
+			"amount":   amount,
+			"locktime": lockTime,
+			"err":      err,
+		}).Error("failed to send bid tx")
 		return err
 	}
 

--- a/pkg/core/consensus/stakeautomaton/stakeautomaton.go
+++ b/pkg/core/consensus/stakeautomaton/stakeautomaton.go
@@ -97,7 +97,7 @@ func (m *StakeAutomaton) sendStake() error {
 	l.WithFields(log.Fields{
 		"amount":   amount,
 		"locktime": lockTime,
-	}).Tracef("Sending stake tx")
+	}).Trace("Sending stake tx")
 
 	req := &node.StakeRequest{
 		Amount:   amount,
@@ -109,6 +109,11 @@ func (m *StakeAutomaton) sendStake() error {
 
 	_, err := m.rpcBus.Call(topics.SendStakeTx, rpcbus.NewRequest(req), timeoutSendStakeTX)
 	if err != nil {
+		l.WithFields(log.Fields{
+			"amount":   amount,
+			"locktime": lockTime,
+			"err":      err,
+		}).Error("error sending stake tx")
 		return err
 	}
 

--- a/pkg/core/transactor/listener.go
+++ b/pkg/core/transactor/listener.go
@@ -82,7 +82,7 @@ func (t *Transactor) handleSendBidTx(req *node.BidRequest) (*node.TransactionRes
 	log.
 		WithField("amount", req.Amount).
 		WithField("locktime", req.Locktime).
-		Tracef("Creating a bid tx")
+		Info("Creating a bid tx")
 
 	// TODO context should be created from the parent one
 	ctx := context.Background()
@@ -132,6 +132,10 @@ func (t *Transactor) handleSendBidTx(req *node.BidRequest) (*node.TransactionRes
 		var height uint64
 		height, err = t.FetchCurrentHeight()
 		if err != nil {
+			log.
+				WithField("amount", req.Amount).
+				WithField("locktime", req.Locktime).
+				Error("FetchCurrentHeight, failed to fetch")
 			return err
 		}
 
@@ -156,6 +160,12 @@ func (t *Transactor) handleSendBidTx(req *node.BidRequest) (*node.TransactionRes
 			Panic("handleSendBidTx, failed to create publishTx")
 	}
 
+	// create and sign transaction
+	log.
+		WithField("amount", req.Amount).
+		WithField("locktime", req.Locktime).
+		Trace("Success creating a bid tx")
+
 	return &node.TransactionResponse{Hash: hash}, nil
 }
 
@@ -168,7 +178,7 @@ func (t *Transactor) handleSendStakeTx(req *node.StakeRequest) (*node.Transactio
 	log.
 		WithField("amount", req.Amount).
 		WithField("locktime", req.Locktime).
-		Tracef("Creating a stake tx")
+		Trace("Creating a stake tx")
 
 	blsKey := t.w.Keys().BLSPubKey
 	if blsKey == nil {
@@ -198,6 +208,11 @@ func (t *Transactor) handleSendStakeTx(req *node.StakeRequest) (*node.Transactio
 		return nil, err
 	}
 
+	log.
+		WithField("amount", req.Amount).
+		WithField("locktime", req.Locktime).
+		Trace("Success creating a stake tx")
+
 	return &node.TransactionResponse{Hash: hash}, nil
 }
 
@@ -210,7 +225,7 @@ func (t *Transactor) handleSendStandardTx(req *node.TransferRequest) (*node.Tran
 	log.
 		WithField("amount", req.Amount).
 		WithField("address", string(req.Address)).
-		Tracef("Create a standard tx")
+		Trace("Create a standard tx")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
 in order to stop having timeout errs in automate bid and stake requests, I've added responses to the requests and this seems to clear the logs.

How to test:
run devnet with automate true
`./devnet.sh -q 3 -r true -b true -d true -a true`

Observe there are no timeout errs.