### PR TITLE
Remove respChan and writeLoop, use response callback directly

### DIFF
--- a/pkg/p2p/peer/factory.go
+++ b/pkg/p2p/peer/factory.go
@@ -8,8 +8,6 @@ package peer
 
 import (
 	"bytes"
-
-	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
 )
 
 // ReaderFactory is responsible for spawning peers. It provides them with the
@@ -25,18 +23,12 @@ func NewReaderFactory(processor *MessageProcessor) *ReaderFactory {
 
 // SpawnReader returns a Reader. It will still need to be launched by
 // running ReadLoop in a goroutine.
-func (f *ReaderFactory) SpawnReader(conn *Connection, responseChan chan<- bytes.Buffer) *Reader {
+func (f *ReaderFactory) SpawnReader(conn *Connection, responseFunc func(bytes.Buffer) error) *Reader {
 	reader := &Reader{
 		Connection:   conn,
-		responseChan: responseChan,
+		responseFunc: responseFunc,
 		processor:    f.processor,
 	}
-
-	// On each new connection the node sends topics.Mempool to retrieve mempool
-	// txs from the new peer
-	go func() {
-		responseChan <- topics.MemPool.ToBuffer()
-	}()
 
 	return reader
 }

--- a/pkg/p2p/peer/handshake_test.go
+++ b/pkg/p2p/peer/handshake_test.go
@@ -37,21 +37,20 @@ func TestHandshake(t *testing.T) {
 
 	client, srv := net.Pipe()
 
+	g := protocol.NewGossip(protocol.TestNet)
+	pConn := NewConnection(client, g)
+	pw := NewWriter(pConn, eb)
+
 	go func() {
-		responseChan := make(chan bytes.Buffer, 100)
 		pConn := NewConnection(srv, protocol.NewGossip(protocol.TestNet))
 
-		peerReader := factory.SpawnReader(pConn, responseChan)
+		peerReader := factory.SpawnReader(pConn, func(bytes.Buffer) error { return nil })
 		if err := peerReader.Accept(protocol.FullNode); err != nil {
 			panic(err)
 		}
 	}()
 
 	time.Sleep(500 * time.Millisecond)
-
-	g := protocol.NewGossip(protocol.TestNet)
-	pConn := NewConnection(client, g)
-	pw := NewWriter(pConn, eb)
 
 	defer func() {
 		_ = pw.Conn.Close()

--- a/pkg/p2p/peer/peer_test.go
+++ b/pkg/p2p/peer/peer_test.go
@@ -9,7 +9,6 @@ package peer
 import (
 	"bytes"
 	"context"
-	"io"
 	"net"
 	"testing"
 	"time"
@@ -21,7 +20,6 @@ import (
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/protocol"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
 	"github.com/dusk-network/dusk-blockchain/pkg/util/nativeutils/eventbus"
-	"github.com/stretchr/testify/assert"
 )
 
 var receiveFn = func(c net.Conn) {
@@ -52,9 +50,8 @@ func TestReader(t *testing.T) {
 	processor.Register(topics.Agreement, respFn)
 	factory := NewReaderFactory(processor)
 
-	responseChan := make(chan bytes.Buffer, 100)
 	pConn := NewConnection(srv, protocol.NewGossip(protocol.TestNet))
-	peerReader := factory.SpawnReader(pConn, responseChan)
+	peerReader := factory.SpawnReader(pConn, func(bytes.Buffer) error { return nil })
 
 	peerReader.services = protocol.FullNode
 
@@ -100,46 +97,6 @@ func TestWriteRingBuffer(t *testing.T) {
 		errList := bus.Publish(topics.Gossip, msg)
 		require.Empty(t, errList)
 	}
-}
-
-// Test the functionality of the peer.Writer through the use of the outgoing message queue.
-func TestWriteLoop(t *testing.T) {
-	bus := eventbus.New()
-	client, srv := net.Pipe()
-
-	g := protocol.NewGossip(protocol.TestNet)
-	msg := makeAgreementGossip(10)
-
-	buf, err := message.Marshal(msg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	go func(g *protocol.Gossip) {
-		responseChan := make(chan bytes.Buffer)
-
-		pConn := NewConnection(client, g)
-		writer := NewWriter(pConn, bus, 30*time.Millisecond)
-
-		writer.services = protocol.FullNode
-		go writer.Serve(context.Background(), responseChan)
-
-		bufCopy := buf
-		responseChan <- bufCopy
-	}(g)
-
-	// Decode and remove magic
-	length, err := g.UnpackLength(srv)
-	assert.NoError(t, err)
-
-	decoded := make([]byte, length)
-	_, err = io.ReadFull(srv, decoded)
-	assert.NoError(t, err)
-
-	// Remove checksum
-	decoded = decoded[4:]
-
-	assert.Equal(t, decoded, (&buf).Bytes())
 }
 
 func BenchmarkWriter(t *testing.B) {


### PR DESCRIPTION
This alleviates the backpressure observed during
times of high load, and simplifies the Peer structure.

Fixes #1070