### PR TITLE
Fix devnet.sh #1079

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -117,6 +117,8 @@ init_dusk_func() {
   timeoutbrokergetcandidate = 2
   timeoutreadwrite = 60
   timeoutkeepalivetime = 30
+  timeoutdial = 5
+
 [genesis]
   legacy = false
 
@@ -168,6 +170,10 @@ enabled = false
 
 [network]
   port = "$((7100+$i))"
+  minimumConnections = 5
+  maxConnections = 50
+  serviceFlag = 1
+
 
   [network.seeder]
     addresses = ["127.0.0.1:8081"]


### PR DESCRIPTION
How to test:
Terminal 1: `./devnet.sh -q 3 -r true -b true -d true -a true`
Terminal 2: `make build && ./bin/utils metrics`
Terminal 3: `watch "curl http://localhost:9099/metrics"`
Terminal 4: `watch "ps -ef |grep dusk"`

Check logs and make sure there are no errs and that there are four instances of Dusk, four instances of mockrusk, one instance of mock and one instance of voucher.