### PR TITLE
Remove APK and step from Agreement message

### DIFF
--- a/pkg/core/consensus/agreement/accumulator.go
+++ b/pkg/core/consensus/agreement/accumulator.go
@@ -60,8 +60,6 @@ func (a *Accumulator) Process(ev message.Agreement) {
 // Accumulate agreements per block hash until a quorum is reached or a stop is detected (by closing the internal event channel). Supposed to run in a goroutine.
 func (a *Accumulator) Accumulate() {
 	for ev := range a.eventChan {
-		// FIXME: republish here to avoid race conditions for slower but safer
-		// re-propagation
 		hdr := ev.State()
 		collected := a.store.Get(hdr.Step)
 		weight := a.handler.VotesFor(hdr.PubKeyBLS, hdr.Round, hdr.Step)

--- a/pkg/core/consensus/reduction/aggregator.go
+++ b/pkg/core/consensus/reduction/aggregator.go
@@ -55,7 +55,7 @@ func (a *Aggregator) CollectVote(ev message.Reduction) *Result {
 		sv.Cluster = sortedset.NewCluster()
 	}
 
-	if err := sv.StepVotes.Add(ev.SignedHash, hdr.PubKeyBLS, hdr.Step); err != nil {
+	if err := sv.StepVotes.Add(ev.SignedHash); err != nil {
 		// adding the vote to the cluster failed. This is a programming error
 		panic(err)
 	}

--- a/pkg/core/consensus/reduction/secondstep/reduction_test.go
+++ b/pkg/core/consensus/reduction/secondstep/reduction_test.go
@@ -37,7 +37,7 @@ func TestSendReduction(t *testing.T) {
 
 	// Generate second StepVotes
 	svs := message.GenVotes(hash, 1, 2, hlp.ProvisionersKeys, hlp.P)
-	msg := message.NewStepVotesMsg(round, hash, hlp.ThisSender, *svs[0])
+	msg := message.NewStepVotesMsg(round, hash, hlp.ThisSender, *svs[0], 0)
 
 	// injecting the stepVotes into secondStep
 	stepFn := secondStep.Initialize(msg)
@@ -175,7 +175,7 @@ func TestSecondStepReduction(t *testing.T) {
 
 			// Generate second StepVotes
 			svs := message.GenVotes(hash, 1, 2, hlp.ProvisionersKeys, hlp.P)
-			msg := message.NewStepVotesMsg(round, hash, hlp.ThisSender, *svs[0])
+			msg := message.NewStepVotesMsg(round, hash, hlp.ThisSender, *svs[0], 0)
 
 			testPhase := consensus.NewTestPhase(t, ttest.testResultFactory, streamer)
 			secondStepReduction.SetNext(testPhase)

--- a/pkg/core/data/ipc/transactions/fixtures.go
+++ b/pkg/core/data/ipc/transactions/fixtures.go
@@ -21,6 +21,8 @@ import (
 	"github.com/dusk-network/dusk-protobuf/autogen/go/rusk"
 )
 
+const stateTransitionDelay = 1 * time.Second
+
 // PermissiveExecutor implements the transactions.Executor interface. It
 // simulates successful Validation and Execution of State transitions
 // all Validation and simulates.
@@ -40,12 +42,14 @@ func MockExecutor(height uint64) *PermissiveExecutor {
 // VerifyStateTransition returns all ContractCalls passed
 // height. It returns those ContractCalls deemed valid.
 func (p *PermissiveExecutor) VerifyStateTransition(ctx context.Context, cc []ContractCall, height uint64) ([]ContractCall, error) {
+	time.Sleep(stateTransitionDelay)
 	return cc, nil
 }
 
 // ExecuteStateTransition performs a global state mutation and steps the
 // block-height up.
 func (p *PermissiveExecutor) ExecuteStateTransition(ctx context.Context, cc []ContractCall, height uint64) (user.Provisioners, error) {
+	time.Sleep(stateTransitionDelay)
 	return *p.P, nil
 }
 

--- a/pkg/p2p/peer/processor.go
+++ b/pkg/p2p/peer/processor.go
@@ -49,10 +49,11 @@ func (m *MessageProcessor) Register(topic topics.Topic, fn ProcessorFunc) {
 // to the processing function.
 func (m *MessageProcessor) Collect(srcPeerID string, packet []byte, respRingBuf *ring.Buffer, services protocol.ServiceFlag, header []byte) ([]bytes.Buffer, error) {
 	b := bytes.NewBuffer(packet)
+	topic := topics.Topic(b.Bytes()[0])
 
 	msg, err := message.Unmarshal(b)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s - topic: %s", err, topic)
 	}
 
 	if header != nil {

--- a/pkg/p2p/peer/processor.go
+++ b/pkg/p2p/peer/processor.go
@@ -8,6 +8,7 @@ package peer
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -48,12 +49,16 @@ func (m *MessageProcessor) Register(topic topics.Topic, fn ProcessorFunc) {
 // Collect a message from the network. The message is unmarshaled and passed down
 // to the processing function.
 func (m *MessageProcessor) Collect(srcPeerID string, packet []byte, respRingBuf *ring.Buffer, services protocol.ServiceFlag, header []byte) ([]bytes.Buffer, error) {
+	if len(packet) == 0 {
+		return nil, errors.New("empty packet provided")
+	}
+
 	b := bytes.NewBuffer(packet)
 	topic := topics.Topic(b.Bytes()[0])
 
 	msg, err := message.Unmarshal(b)
 	if err != nil {
-		return nil, fmt.Errorf("%s - topic: %s", err, topic)
+		return nil, fmt.Errorf("error while unmarshaling: %s - topic: %s", err, topic)
 	}
 
 	if header != nil {
@@ -97,7 +102,7 @@ func (m *MessageProcessor) process(srcPeerID string, msg message.Message, respRi
 
 	bufs, err := processFn(srcPeerID, msg)
 	if err != nil {
-		return nil, fmt.Errorf("%s - topic %s", err, msg.Category())
+		return nil, fmt.Errorf("error while processing: %s - topic %s", err, msg.Category())
 	}
 
 	if respRingBuf != nil {

--- a/pkg/p2p/wire/message/score.go
+++ b/pkg/p2p/wire/message/score.go
@@ -18,17 +18,15 @@ import (
 	crypto "github.com/dusk-network/dusk-crypto/hash"
 )
 
-type (
-	// Score extends the ScoreProposal with additional fields related to the
-	// candidate it pairs up with. The Score is supposed to be immutable once
-	// created and it gets forwarded to the other nodes.
-	Score struct {
-		hdr        header.Header
-		PrevHash   []byte
-		Candidate  block.Block
-		SignedHash []byte
-	}
-)
+// Score extends the ScoreProposal with additional fields related to the
+// candidate it pairs up with. The Score is supposed to be immutable once
+// created and it gets forwarded to the other nodes.
+type Score struct {
+	hdr        header.Header
+	PrevHash   []byte
+	Candidate  block.Block
+	SignedHash []byte
+}
 
 // NewScore creates a new Score from a proposal.
 func NewScore(hdr header.Header, prevHash []byte, candidate block.Block) *Score {

--- a/pkg/util/ruskmock/server.go
+++ b/pkg/util/ruskmock/server.go
@@ -185,6 +185,8 @@ func (s *Server) ExecuteStateTransition(ctx context.Context, req *rusk.ExecuteSt
 		}, nil
 	}
 
+	log.Infoln("converting txs")
+
 	txs, err := legacy.ContractCallsToTxs(req.Txs)
 	if err != nil {
 		log.WithError(err).Errorln("could not convert contract calls to legacy txs")
@@ -194,6 +196,8 @@ func (s *Server) ExecuteStateTransition(ctx context.Context, req *rusk.ExecuteSt
 	blk := block.NewBlock()
 	blk.Txs = txs
 	blk.Header.Height = req.Height
+
+	log.Infoln("checking wire block")
 
 	_, _, err = s.w.CheckWireBlock(*blk)
 	if err != nil {


### PR DESCRIPTION
These items were not used at all, the step wasn't even unmarshaled.
This should get rid of our malformed point error, as it originated
in unmarshaling the APK, which now no longer exists on that message.

Fixes #271, fixes #1085