### PR TITLE
Terminate gracefully all subsystems/components and pending grpc requests

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -51,14 +51,23 @@ const voucherRetryTime = 15 * time.Second
 
 // Server is the main process of the node.
 type Server struct {
-	eventBus      *eventbus.EventBus
-	rpcBus        *rpcbus.RPCBus
-	c             *chain.Chain
-	gossip        *protocol.Gossip
-	grpcServer    *grpc.Server
+	eventBus *eventbus.EventBus
+	rpcBus   *rpcbus.RPCBus
+	c        *chain.Chain
+	gossip   *protocol.Gossip
+
+	grpcServer *grpc.Server
+	gqlServer  *gql.Server
+
 	ruskConn      *grpc.ClientConn
 	readerFactory *peer.ReaderFactory
 	kadPeer       *kadcast.Peer
+
+	dbDriver database.Driver
+
+	// Parent context to all long-lived goroutines triggered by any subsystem.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // LaunchChain instantiates a chain.Loader, does the wire up to create a Chain
@@ -82,9 +91,9 @@ func LaunchChain(ctx context.Context, cl *loop.Consensus, proxy transactions.Pro
 	return chainProcess, nil
 }
 
-func (s *Server) launchKadcastPeer(p *peer.MessageProcessor, g *protocol.Gossip) {
+func (s *Server) launchKadcastPeer(ctx context.Context, p *peer.MessageProcessor, g *protocol.Gossip) {
 	// launch kadcast client
-	kadPeer := kadcast.NewKadcastPeer(s.eventBus, p, g)
+	kadPeer := kadcast.NewKadcastPeer(ctx, s.eventBus, p, g)
 	kadPeer.Launch()
 	s.kadPeer = kadPeer
 }
@@ -117,7 +126,7 @@ func readPassword(prompt string) ([]byte, error) {
 func Setup() *Server {
 	var pw string
 
-	ctx := context.Background()
+	parentCtx, parentCancel := context.WithCancel(context.Background())
 	_, err := os.Stat(cfg.Get().Wallet.File)
 
 	switch {
@@ -162,14 +171,14 @@ func Setup() *Server {
 	eventBus := eventbus.New()
 	rpcBus := rpcbus.New()
 
-	_, db := heavy.CreateDBConnection()
+	driver, db := heavy.CreateDBConnection()
 
 	processor := peer.NewMessageProcessor(eventBus)
 	registerPeerServices(processor, db, eventBus, rpcBus)
 
 	// Instantiate gRPC client
 	// TODO: get address from config
-	gctx, cancel := context.WithTimeout(ctx, time.Duration(cfg.Get().RPC.Rusk.ConnectionTimeout)*time.Millisecond)
+	gctx, cancel := context.WithTimeout(parentCtx, time.Duration(cfg.Get().RPC.Rusk.ConnectionTimeout)*time.Millisecond)
 	defer cancel()
 
 	proxy, ruskConn := setupGRPCClients(gctx)
@@ -187,7 +196,7 @@ func Setup() *Server {
 	}
 
 	m := mempool.NewMempool(eventBus, rpcBus, proxy.Prober(), grpcServer)
-	m.Run(ctx)
+	m.Run(parentCtx)
 	processor.Register(topics.Tx, m.ProcessTx)
 
 	// Instantiate API server
@@ -213,7 +222,7 @@ func Setup() *Server {
 	cl := loop.New(e, &w.PublicKey)
 	processor.Register(topics.Candidate, cl.ProcessCandidate)
 
-	c, err := LaunchChain(ctx, cl, proxy, eventBus, rpcBus, grpcServer, db)
+	c, err := LaunchChain(parentCtx, cl, proxy, eventBus, rpcBus, grpcServer, db)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -221,12 +230,14 @@ func Setup() *Server {
 	processor.Register(topics.Block, c.ProcessBlockFromNetwork)
 
 	// Instantiate GraphQL server
+	var gqlServer *gql.Server
 	if cfg.Get().Gql.Enabled {
-		if gqlServer, e := gql.NewHTTPServer(eventBus, rpcBus); e != nil {
-			log.Errorf("GraphQL http server error: %v", e)
+		var e error
+		if gqlServer, e = gql.NewHTTPServer(eventBus, rpcBus); e != nil {
+			log.WithError(e).Error("graphq server failed to run")
 		} else {
-			if e := gqlServer.Start(); e != nil {
-				log.Errorf("GraphQL failed to start: %v", e)
+			if e = gqlServer.Start(parentCtx); e != nil {
+				log.WithError(e).Error("graphq server failed to run")
 			}
 		}
 	}
@@ -252,9 +263,13 @@ func Setup() *Server {
 		rpcBus:        rpcBus,
 		c:             c,
 		gossip:        gossip,
+		gqlServer:     gqlServer,
 		grpcServer:    grpcServer,
 		ruskConn:      ruskConn,
 		readerFactory: readerFactory,
+		dbDriver:      driver,
+		ctx:           parentCtx,
+		cancel:        parentCancel,
 	}
 
 	// Setting up the transactor component
@@ -268,7 +283,7 @@ func Setup() *Server {
 	// Setting up and launch kadcast peer
 	kcfg := cfg.Get().Kadcast
 	if kcfg.Enabled {
-		srv.launchKadcastPeer(processor, gossip)
+		srv.launchKadcastPeer(parentCtx, processor, gossip)
 	}
 
 	// Start serving from the gRPC server
@@ -299,16 +314,27 @@ func Setup() *Server {
 
 // Close the chain and the connections created through the RPC bus.
 func (s *Server) Close() {
-	// TODO: disconnect peers
-	// _ = s.c.Close(cfg.Get().Database.Driver)
+	// Cancel all goroutines long-lived loops
+	s.cancel()
+
+	// Close graphql server.
+	if s.gqlServer != nil {
+		s.gqlServer.Close()
+	}
+
 	s.rpcBus.Close()
 	s.grpcServer.GracefulStop()
 	_ = s.ruskConn.Close()
 
-	// kadcast grpc
+	// kadcast client grpc
 	if s.kadPeer != nil {
 		s.kadPeer.Close()
 	}
+
+	if s.dbDriver != nil {
+		s.dbDriver.Close()
+	}
+
 }
 
 func connectToSeeders(connector *peer.Connector, seeders []string) error {

--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -187,7 +187,7 @@ func (m *Mempool) Loop(ctx context.Context) {
 		case <-ticker.C:
 			m.onIdle()
 		case <-ctx.Done():
-			// Mempool terminating
+			log.Info("main_loop terminated")
 			return
 		}
 
@@ -226,6 +226,7 @@ func (m *Mempool) propagateLoop(ctx context.Context) {
 
 		// Mempool terminating
 		case <-ctx.Done():
+			log.Info("propagate_loop terminated")
 			return
 		}
 	}

--- a/pkg/gql/httpserver.go
+++ b/pkg/gql/httpserver.go
@@ -92,6 +92,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Set up HTTP Server over TCP
 	lc := net.ListenConfig{}
+
 	l, err := lc.Listen(ctx, conf.Network, conf.Address)
 	if err != nil {
 		return err
@@ -226,7 +227,6 @@ func (s *Server) Close() error {
 	defer cancel()
 
 	if err := s.httpServer.Shutdown(dialCtx); err != nil {
-		log.WithError(err).Warn("error shutting down")
 		return err
 	}
 

--- a/pkg/gql/httpserver_test.go
+++ b/pkg/gql/httpserver_test.go
@@ -59,7 +59,7 @@ func TestMultiClient(t *testing.T) {
 	s, eb, err := createServer(srvAddr, brokersNum, maxAllowedClients/brokersNum, enableTLS)
 	assert.NoError(err)
 
-	defer s.Stop()
+	defer s.Close()
 
 	// Set up a list of ws clients
 	resp := make(chan string, clientsNum)
@@ -159,7 +159,7 @@ func createServer(addr string, brokerNum, clientsPerBroker uint, enableTLS bool)
 		return nil, nil, err
 	}
 
-	return s, eb, s.Start()
+	return s, eb, s.Start(context.Background())
 }
 
 func publishRandBlock(eb *eventbus.EventBus, assert *assert.Assertions) {

--- a/pkg/p2p/kadcast/peer.go
+++ b/pkg/p2p/kadcast/peer.go
@@ -39,8 +39,8 @@ type Peer struct {
 }
 
 // NewKadcastPeer returns a new kadcast (gRPC interface) peer instance.
-func NewKadcastPeer(eventBus *eventbus.EventBus, processor *peer.MessageProcessor, gossip *protocol.Gossip) *Peer {
-	ctx, cancel := context.WithCancel(context.Background())
+func NewKadcastPeer(pCtx context.Context, eventBus *eventbus.EventBus, processor *peer.MessageProcessor, gossip *protocol.Gossip) *Peer {
+	ctx, cancel := context.WithCancel(pCtx)
 	return &Peer{
 		eventBus:  eventBus,
 		processor: processor,

--- a/pkg/p2p/kadcast/reader.go
+++ b/pkg/p2p/kadcast/reader.go
@@ -121,16 +121,19 @@ func (r *Reader) processMessage(msg *rusk.Message) {
 }
 
 func reportStreamErr(err error) {
-	m := "stream terminated"
+	m := "listener_loop terminated"
 
 	s, ok := status.FromError(err)
 	if ok {
 		switch s.Code() {
 		case codes.Canceled:
 			// canceling
-			log.Info(m + " gracefully")
+			log.Info(m)
+
 		default:
-			log.WithField("code", s.Code()).WithError(err).Warn(m)
+			log.
+				WithField("code", s.Code()).
+				WithError(err).Warn(m)
 		}
 		return
 	}

--- a/pkg/util/nativeutils/eventbus/eventbus.go
+++ b/pkg/util/nativeutils/eventbus/eventbus.go
@@ -37,6 +37,7 @@ func New() *EventBus {
 	}
 }
 
+// Close closes all topic listeners.
 func (e *EventBus) Close() {
 	e.listeners.Close()
 	e.defaultListener.Close()

--- a/pkg/util/nativeutils/eventbus/eventbus.go
+++ b/pkg/util/nativeutils/eventbus/eventbus.go
@@ -36,3 +36,8 @@ func New() *EventBus {
 		defaultListener: newMultiListener(),
 	}
 }
+
+func (e *EventBus) Close() {
+	e.listeners.Close()
+	e.defaultListener.Close()
+}

--- a/pkg/util/nativeutils/eventbus/listener.go
+++ b/pkg/util/nativeutils/eventbus/listener.go
@@ -306,3 +306,14 @@ func (m *multiListener) Delete(id uint32) bool {
 
 	return false
 }
+
+func (m *multiListener) Close() {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, h := range m.dispatchers {
+		h.Close()
+	}
+
+	m.dispatchers = nil
+}

--- a/pkg/util/nativeutils/eventbus/listenermap.go
+++ b/pkg/util/nativeutils/eventbus/listenermap.go
@@ -83,3 +83,16 @@ func (h *listenerMap) Delete(key topics.Topic, id uint32) bool {
 	h.lock.Unlock()
 	return found
 }
+
+func (h *listenerMap) Close() {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	for _, listeners := range h.listeners {
+		for _, listener := range listeners {
+			listener.Close()
+		}
+	}
+
+	h.listeners = nil
+}


### PR DESCRIPTION
fixes #1241 

- Cancel all goroutine loops (kadcast listener, consensus, mempool, chain, gossip read loop)
- Close non-cancelable components (db driver, gql server, eventbus)
- Cancel pending grpc client requests on state/network services.