### PR TITLE
Mempool extraction by GasPrice

### DIFF
--- a/pkg/core/data/ipc/transactions/transaction.go
+++ b/pkg/core/data/ipc/transactions/transaction.go
@@ -68,7 +68,7 @@ func (t Transaction) deepCopy() *Transaction {
 	}
 }
 
-// Fee returns GasLimit.
+// Fee returns GasPrice.
 func (t Transaction) Fee() (uint64, error) {
 	if t.Payload == nil {
 		return 0, errors.New("payload is nil")
@@ -79,7 +79,7 @@ func (t Transaction) Fee() (uint64, error) {
 		return 0, err
 	}
 
-	return decoded.Fee.GasLimit, nil
+	return decoded.Fee.GasPrice, nil
 }
 
 // GasSpent returns gas spent on transaction execution.


### PR DESCRIPTION
`Fee()` returns GasPrice instead of GasLimit
`Fee()` is used to RangeSort txs extraction

See also dusk-network/rusk#605
See also #1240 