### PR TITLE
Reduce wire messages needed for propagating and registering Agreement vote

### DIFF
--- a/pkg/core/consensus/fixtures.go
+++ b/pkg/core/consensus/fixtures.go
@@ -144,7 +144,7 @@ func MockPhase(cb func(ctx context.Context) bool) Phase {
 }
 
 // TestCallback is a callback to allow for table testing based on step results.
-type TestCallback func(*require.Assertions, InternalPacket, *eventbus.GossipStreamer)
+type TestCallback func(*require.Assertions, InternalPacket, *eventbus.GossipStreamer, chan message.Message)
 
 // TestPhase is the phase to inject in the step under test to allow for table
 // testing. It treats the packet injected through the Fn method as the result
@@ -154,14 +154,17 @@ type TestPhase struct {
 	packet   InternalPacket
 	req      *require.Assertions
 	streamer *eventbus.GossipStreamer
+
+	aChan chan message.Message
 }
 
 // NewTestPhase returns a Phase implementation suitable for testing steps.
-func NewTestPhase(t *testing.T, callback TestCallback, streamer *eventbus.GossipStreamer) *TestPhase {
+func NewTestPhase(t *testing.T, callback TestCallback, streamer *eventbus.GossipStreamer, aChan chan message.Message) *TestPhase {
 	return &TestPhase{
 		req:      require.New(t),
 		callback: callback,
 		streamer: streamer,
+		aChan:    aChan,
 	}
 }
 
@@ -177,7 +180,7 @@ func (t *TestPhase) Initialize(sv InternalPacket) PhaseFn {
 
 // Run does nothing else than delegating to the specified callback.
 func (t *TestPhase) Run(_ context.Context, queue *Queue, _ chan message.Message, _ RoundUpdate, step uint8) PhaseFn {
-	t.callback(t.req, t.packet, t.streamer)
+	t.callback(t.req, t.packet, t.streamer, t.aChan)
 	return nil
 }
 

--- a/pkg/core/consensus/reduction/firststep/reduction_test.go
+++ b/pkg/core/consensus/reduction/firststep/reduction_test.go
@@ -57,7 +57,7 @@ func initiateTableTest(hlp *reduction.Helper, timeout time.Duration, hash []byte
 				return evChan
 			},
 
-			testResultFactory: func(require *require.Assertions, packet consensus.InternalPacket, _ *eventbus.GossipStreamer) {
+			testResultFactory: func(require *require.Assertions, packet consensus.InternalPacket, _ *eventbus.GossipStreamer, aChan chan message.Message) {
 				require.NotNil(packet)
 
 				stepVoteMessage := packet.(message.StepVotesMsg)
@@ -84,7 +84,7 @@ func initiateTableTest(hlp *reduction.Helper, timeout time.Duration, hash []byte
 			},
 
 			// the result of the test should be empty step votes
-			testResultFactory: func(require *require.Assertions, packet consensus.InternalPacket, _ *eventbus.GossipStreamer) {
+			testResultFactory: func(require *require.Assertions, packet consensus.InternalPacket, _ *eventbus.GossipStreamer, aChan chan message.Message) {
 				require.NotNil(packet)
 				stepVoteMessage := packet.(message.StepVotesMsg)
 				require.True(stepVoteMessage.IsEmpty())
@@ -119,7 +119,7 @@ func TestFirstStepReduction(t *testing.T) {
 			evChan := ttest.batchEvents()
 
 			// injecting the test phase in the reduction step
-			testPhase := consensus.NewTestPhase(t, ttest.testResultFactory, nil)
+			testPhase := consensus.NewTestPhase(t, ttest.testResultFactory, nil, nil)
 			_, db := lite.CreateDBConnection()
 			firstStepReduction := New(testPhase, hlp.Emitter, hlp.ProcessCandidateVerificationRequest, timeout, db, nil)
 

--- a/pkg/core/consensus/reduction/secondstep/step.go
+++ b/pkg/core/consensus/reduction/secondstep/step.go
@@ -267,14 +267,12 @@ func (p *Phase) sendAgreement(round uint64, step uint8, svm *message.StepVotesMs
 	lg.WithFields(log.Fields{
 		"round": round,
 		"step":  step,
-	}).Traceln("gossiping_agreement")
+	}).Traceln("publishing_agreement_internally")
 
+	// Publishing Agreement internally so that it's the internal Agreement process(goroutine)
+	// that should register it locally and only then broadcast it.
 	m := message.NewWithHeader(topics.Agreement, *ev, config.KadcastInitHeader)
-	if err := p.Republish(m); err != nil {
-		lg.
-			WithError(err).
-			Error("gossip the agreement reported error, consensus is continuing but this needs to be investigated!")
-	}
+	p.EventBus.Publish(topics.Agreement, m)
 }
 
 func stepVotesAreValid(svs ...*message.StepVotesMsg) bool {

--- a/pkg/core/consensus/selection/selector_test.go
+++ b/pkg/core/consensus/selection/selector_test.go
@@ -45,13 +45,13 @@ func TestSelection(t *testing.T) {
 
 	for name, ttest := range table {
 		t.Run(name, func(t *testing.T) {
-			ttestCB := func(require *require.Assertions, p consensus.InternalPacket, _ *eventbus.GossipStreamer) {
+			ttestCB := func(require *require.Assertions, p consensus.InternalPacket, _ *eventbus.GossipStreamer, aChan chan message.Message) {
 				require.NotNil(p)
 				messageNewBlock := p.(message.NewBlock)
 				require.NotEmpty(messageNewBlock)
 			}
 
-			testPhase := consensus.NewTestPhase(t, ttestCB, nil)
+			testPhase := consensus.NewTestPhase(t, ttestCB, nil, nil)
 			sel := selection.New(testPhase, ttest.bg, hlp.Emitter, consensusTimeOut, db)
 			selFn := sel.Initialize(nil)
 


### PR DESCRIPTION
fixes #1383 

As a proof, single-node network is now able to reach quorum.

```json

{
  "bitset": "1",
  "event": "quorum_reached",
  "hash": "cc6ae795b7...7c1ecc2105",
  "level": "debug",
  "msg": "",
  "node_id": "7100",
  "process": "consensus",
  "provs": [
    "BLS key: ada282d4c9...6ebe52046c, Stakes: [Value: 2000000000000000, Reward: 720000000000, Counter: 0, Eligibility: 0]"
  ],
  "quorum_target": 1,
  "round": 51,
  "s_voted_c": [
    "Key: ada282d4c9...6ebe52046c, Count: 1"
  ],
  "s_voting_c": [
    "Key: ada282d4c9...6ebe52046c, Count: 1"
  ],
  "step": 6,
  "time": "2022-05-17T10:17:54",
  "total_votes": 1
}

```