### PR TITLE
Make `BlockGasLimit` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Adapt to the new and improved reward strategy [#1320](https://github.com/dusk-network/dusk-blockchain/issues/1320)
-- Include BlockGenerator reward into the header [#1368](https://github.com/dusk-network/dusk-blockchain/issues/1368)
-- Search txs up to 10.000 blocks [#1401](https://github.com/dusk-network/dusk-blockchain/issues/1401)
-- Mempool updates its state at start-up automatically [#1258](https://github.com/dusk-network/dusk-blockchain/issues/1258)
-- Mempool discards any transaction with repeated nullifier [#1388](https://github.com/dusk-network/dusk-blockchain/issues/1388)
+- Make BlockGasLimit configurable [#1418]
+- Adapt to the new and improved reward strategy [#1320]
+- Include BlockGenerator reward into the header [#1368]
+- Search txs up to 10.000 blocks [#1401]
+- Mempool updates its state at start-up automatically [#1258]
+- Mempool discards any transaction with repeated nullifier [#1388]
 
 ### Changed
+- Add GasLimit to the Block's header [#1416]
 - Reduce wire messages needed for propagating an Agreement vote
-- Improve fallback procedure to revert multiple ephemeral blocks [#1343](https://github.com/dusk-network/dusk-blockchain/issues/1343)
-- Disable provisioners records storing in api.db   [#1361](https://github.com/dusk-network/dusk-blockchain/issues/1361)
-- Optimize VST calls of a Provisioner per a consensus iteration [#1371](https://github.com/dusk-network/dusk-blockchain/issues/1371)
-- Call VerifyStateTransition in Reduction 2 only if it is a committee member [#1357](https://github.com/dusk-network/dusk-blockchain/issues/1357)
+- Improve fallback procedure to revert multiple ephemeral blocks [#1343]
+- Disable provisioners records storing in api.db  [#1361]
+- Optimize VST calls of a Provisioner per a consensus iteration [#1371]
+- Call VerifyStateTransition in Reduction 2 only if it is a committee member [#1357]
 
 ### Security
-- Ensure candidate block hash is equal to the BlockHash of the msg.header [#1364](https://github.com/dusk-network/dusk-blockchain/issues/1364)
-- Check quorum per each reduction step on agreement msg verification [#1373](https://github.com/dusk-network/dusk-blockchain/issues/1373)
-- Extend reduction 1 verification procedure with VST call [#1358](https://github.com/dusk-network/dusk-blockchain/issues/1358)
+- Ensure candidate block hash is equal to the BlockHash of the msg.header [#1364]
+- Check quorum per each reduction step on agreement msg verification [#1373]
+- Extend reduction 1 verification procedure with VST call [#1358]
+
+### Fixed
+- Default configuration values loading [#1419] 
+
+[#1419]: (https://github.com/dusk-network/dusk-blockchain/issues/1419)
+[#1418]: (https://github.com/dusk-network/dusk-blockchain/issues/1418)
+[#1416]: (https://github.com/dusk-network/dusk-blockchain/issues/1416)
+[#1401]: (https://github.com/dusk-network/dusk-blockchain/issues/1401)
+[#1388]: (https://github.com/dusk-network/dusk-blockchain/issues/1388)
+[#1373]: (https://github.com/dusk-network/dusk-blockchain/issues/1373)
+[#1371]: (https://github.com/dusk-network/dusk-blockchain/issues/1371)
+[#1368]: (https://github.com/dusk-network/dusk-blockchain/issues/1368)
+[#1364]: (https://github.com/dusk-network/dusk-blockchain/issues/1364)
+[#1361]: (https://github.com/dusk-network/dusk-blockchain/issues/1361)
+[#1358]: (https://github.com/dusk-network/dusk-blockchain/issues/1358)
+[#1357]: (https://github.com/dusk-network/dusk-blockchain/issues/1357)
+[#1343]: (https://github.com/dusk-network/dusk-blockchain/issues/1343)
+[#1320]: (https://github.com/dusk-network/dusk-blockchain/issues/1320)
+[#1258]: (https://github.com/dusk-network/dusk-blockchain/issues/1258)
+
+
+<!-- Releases -->
+
+[Unreleased]: https://github.com/dusk-network/dusk-blockchain/compare/daybreak-20220321...HEAD

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -15,7 +15,7 @@ const (
 
 	// Default Block Gas limit.
 	// This value should handle up to ~20 transfers (or ~5 InterContract calls) per block.
-	BlockGasLimit = 5 * DUSK
+	DefaultBlockGasLimit = 5 * DUSK
 
 	// MaxTxSetSize defines the maximum amount of transactions.
 	// It is TBD along with block size and processing.MaxFrameSize.

--- a/pkg/config/groups.go
+++ b/pkg/config/groups.go
@@ -217,5 +217,6 @@ type consensusConfiguration struct {
 
 type stateConfiguration struct {
 	// PersistEvery N blocks the state in rusk
-	PersistEvery uint64
+	PersistEvery  uint64
+	BlockGasLimit uint64
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -262,4 +262,5 @@ func init() {
 	r.Timeout.TimeoutBrokerGetCandidate = 2
 	r.Mempool.MaxInvItems = 10000
 	r.State.PersistEvery = 1
+	r.State.BlockGasLimit = DefaultBlockGasLimit
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -85,8 +85,6 @@ type Registry struct {
 // Dusk configuration file can be in form of TOML, JSON, YAML, HCL or Java
 // properties config files.
 func Load(configFileName string, secondary interface{}, customflags func() (string, error)) error {
-	r = new(Registry)
-	r.lock = new(sync.RWMutex)
 	r.ConfigFileName = configFileName
 
 	r.loadFlagsFn = loadFlags

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -40,6 +40,10 @@ func TestDefaultConfigTOML(t *testing.T) {
 	if Get().Logger.Level != "debug" { //nolint
 		t.Error("Invalid logger level")
 	}
+
+	if Get().State.BlockGasLimit != DefaultBlockGasLimit { //nolint
+		t.Errorf("Invalid block gas limit: %d", Get().State.BlockGasLimit)
+	}
 }
 
 // TestSupportedFlags to ensure all supported flags are properly bound and they

--- a/pkg/core/chain/chain.go
+++ b/pkg/core/chain/chain.go
@@ -698,8 +698,8 @@ func (c *Chain) VerifyCandidateBlock(blk block.Block) error {
 }
 
 // ExecuteStateTransition calls Rusk ExecuteStateTransitiongrpc method.
-func (c *Chain) ExecuteStateTransition(ctx context.Context, txs []transactions.ContractCall, blockHeight uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
-	return c.proxy.Executor().ExecuteStateTransition(c.ctx, txs, config.BlockGasLimit, blockHeight, generator)
+func (c *Chain) ExecuteStateTransition(ctx context.Context, txs []transactions.ContractCall, blockHeight uint64, blockGasLimit uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
+	return c.proxy.Executor().ExecuteStateTransition(c.ctx, txs, blockGasLimit, blockHeight, generator)
 }
 
 // propagateBlock send inventory message to all peers in gossip network or rebroadcast block in kadcast network.

--- a/pkg/core/consensus/blockgenerator/candidate/blockgenerator.go
+++ b/pkg/core/consensus/blockgenerator/candidate/blockgenerator.go
@@ -114,8 +114,8 @@ func (bg *generator) Generate(seed []byte, keys [][]byte, r consensus.RoundUpdat
 	return bg.GenerateBlock(r.Round, seed, r.Hash, r.Timestamp, keys)
 }
 
-func (bg *generator) execute(ctx context.Context, txs []transactions.ContractCall, round uint64) ([]transactions.ContractCall, []byte, error) {
-	txs, stateHash, err := bg.executeFn(ctx, txs, round, bg.Keys.BLSPubKey)
+func (bg *generator) execute(ctx context.Context, txs []transactions.ContractCall, round uint64, gasLimit uint64) ([]transactions.ContractCall, []byte, error) {
+	txs, stateHash, err := bg.executeFn(ctx, txs, round, gasLimit, bg.Keys.BLSPubKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -162,7 +162,9 @@ func (bg *generator) GenerateBlock(round uint64, seed, prevBlockHash []byte, pre
 		return nil, err
 	}
 
-	txs, stateHash, err := bg.execute(context.Background(), txs, round)
+	blockGasLimit := config.Get().State.BlockGasLimit
+
+	txs, stateHash, err := bg.execute(context.Background(), txs, round, blockGasLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +191,7 @@ func (bg *generator) GenerateBlock(round uint64, seed, prevBlockHash []byte, pre
 		Seed:               seed,
 		Certificate:        block.EmptyCertificate(),
 		StateHash:          stateHash,
-		GasLimit:           config.BlockGasLimit,
+		GasLimit:           blockGasLimit,
 	}
 
 	// Construct the candidate block

--- a/pkg/core/consensus/blockgenerator/candidate/generator_test.go
+++ b/pkg/core/consensus/blockgenerator/candidate/generator_test.go
@@ -25,7 +25,7 @@ func TestGenerate(t *testing.T) {
 
 	hlp := candidate.NewHelper(50, time.Second)
 
-	fn := func(ctx context.Context, txs []transactions.ContractCall, h uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
+	fn := func(ctx context.Context, txs []transactions.ContractCall, h uint64, gaslimit uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
 		return []transactions.ContractCall{transactions.RandTx()}, make([]byte, 32), nil
 	}
 

--- a/pkg/core/consensus/blockgenerator/candidate/genesis.go
+++ b/pkg/core/consensus/blockgenerator/candidate/genesis.go
@@ -22,7 +22,7 @@ import (
 // as they would be different per network type. Once a genesis block is
 // approved, its hex blob should be copied into config.TestNetGenesisBlob.
 func GenerateGenesisBlock(e *consensus.Emitter) (string, error) {
-	f := func(ctx context.Context, txs []transactions.ContractCall, bh uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
+	f := func(ctx context.Context, txs []transactions.ContractCall, bh uint64, gasLimit uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
 		return txs, make([]byte, 32), nil
 	}
 

--- a/pkg/core/consensus/blockgenerator/candidate/mock.go
+++ b/pkg/core/consensus/blockgenerator/candidate/mock.go
@@ -52,7 +52,7 @@ func (m *mock) GenerateCandidateMessage(ctx context.Context, r consensus.RoundUp
 
 // Mock the candidate generator.
 func Mock(e *consensus.Emitter) Generator {
-	fn := func(ctx context.Context, txs []transactions.ContractCall, bh uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
+	fn := func(ctx context.Context, txs []transactions.ContractCall, bh uint64, gasLimit uint64, generator []byte) ([]transactions.ContractCall, []byte, error) {
 		if len(txs) == 0 {
 			// Function simulates Rusk ExecuteStateTransition.
 			// That said, it should always provide a Distribute transaction

--- a/pkg/core/consensus/comms.go
+++ b/pkg/core/consensus/comms.go
@@ -42,7 +42,7 @@ type (
 	CandidateVerificationFunc func(block.Block) error
 
 	// ExecuteTxsFunc is a callback used to retrieve a valid set of txs.
-	ExecuteTxsFunc func(ctx context.Context, txs []transactions.ContractCall, blockHeight uint64, generator []byte) ([]transactions.ContractCall, []byte, error)
+	ExecuteTxsFunc func(ctx context.Context, txs []transactions.ContractCall, blockHeight uint64, gasLimit uint64, generator []byte) ([]transactions.ContractCall, []byte, error)
 
 	// Emitter is a simple struct to pass the communication channels that the steps should be
 	// able to emit onto.

--- a/pkg/core/data/ipc/transactions/provider.go
+++ b/pkg/core/data/ipc/transactions/provider.go
@@ -94,7 +94,7 @@ func (v *verifier) Preverify(ctx context.Context, call ContractCall) ([]byte, Fe
 		return nil, Fee{}, decodeErr
 	}
 
-	if decoded.Fee.GasLimit >= config.BlockGasLimit {
+	if decoded.Fee.GasLimit >= config.Get().State.BlockGasLimit {
 		return nil, Fee{}, errors.New("tx gas limit exceeds the block gas limit")
 	}
 


### PR DESCRIPTION
### Add configuration entry
A new configuration entry has been added to the `State` config section.
If not specified, it default to `const.DefaultBlockGasLimit`

### Fix configuration loader
- Remove Registry initialization from `cfg.Load` method. That was overriding the default values set by `init` method
- Add test to check default values

Resolves #1418
Resolves #1419