### PR TITLE
Fix consensus timeout configuration

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -141,7 +141,7 @@ func Setup() *Server {
 		EventBus:    eventBus,
 		RPCBus:      rpcBus,
 		Keys:        keys,
-		TimerLength: cfg.ConsensusTimeOut,
+		TimerLength: time.Duration(cfg.Get().Consensus.ConsensusTimeOut) * time.Second,
 	}
 
 	cl := loop.New(e)

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -6,8 +6,6 @@
 
 package config
 
-import "time"
-
 // A single point of constants definition.
 const (
 	// DUSK is one whole unit of DUSK.
@@ -40,7 +38,7 @@ const (
 
 	// Consensus-related settings
 	// Protocol-based consensus step time.
-	ConsensusTimeOut = 5 * time.Second
+	DefaultConsensusTimeOutSeconds = 5
 
 	// ConsensusTimeThreshold consensus time in seconds above which we don't throttle it.
 	ConsensusTimeThreshold = 10

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -256,7 +256,7 @@ func init() {
 	r.Wallet.Store = "walletDB"
 	r.Consensus.DefaultLockTime = 1000
 	r.Consensus.DefaultAmount = 10
-	r.Consensus.ConsensusTimeOut = 5
+	r.Consensus.ConsensusTimeOut = DefaultConsensusTimeOutSeconds
 	r.Timeout.TimeoutBrokerGetCandidate = 2
 	r.Mempool.MaxInvItems = 10000
 	r.State.PersistEvery = 1


### PR DESCRIPTION
ConsensusTimeout is now initialized with DefaultConsensusTimeout (5 seconds) but can be overrode using the custom configuration

Resolves #1423