### PR TITLE
Update getRoundUpdate method to return a deep copy

### DIFF
--- a/harness/engine/utils.go
+++ b/harness/engine/utils.go
@@ -597,7 +597,7 @@ func (n *Network) MonitorTPS(delay time.Duration) {
 			continue
 		}
 
-		if lastHeight == h {
+		if lastHeight == h || h == 1 {
 			// do not print if height is the same
 			continue
 		}

--- a/pkg/core/chain/chain.go
+++ b/pkg/core/chain/chain.go
@@ -753,15 +753,18 @@ func (c *Chain) kadcastBlock(blk block.Block, kadcastHeight byte) error {
 	return nil
 }
 
+// getRoundUpdate constructs RoundUpdate and returns a deep copy.
 func (c *Chain) getRoundUpdate() consensus.RoundUpdate {
-	return consensus.RoundUpdate{
+	r := consensus.RoundUpdate{
 		Round:           c.tip.Header.Height + 1,
-		P:               c.p.Copy(),
+		P:               *c.p,
 		Seed:            c.tip.Header.Seed,
 		Hash:            c.tip.Header.Hash,
 		LastCertificate: c.tip.Header.Certificate,
 		Timestamp:       c.tip.Header.Timestamp,
 	}
+
+	return r.Copy().(consensus.RoundUpdate)
 }
 
 // GetSyncProgress returns how close the node is to being synced to the tip,

--- a/pkg/core/consensus/reduction/reduction.go
+++ b/pkg/core/consensus/reduction/reduction.go
@@ -176,19 +176,22 @@ func ShouldProcess(m message.Message, round uint64, step uint8, queue *consensus
 		return false
 	}
 
-	// Only store events up to 10 rounds into the future
 	// XXX: According to protocol specs, we should abandon consensus
 	// if we notice valid messages from far into the future.
-	if cmp == header.After && hdr.Round-round < 10 {
-		lg.
-			WithFields(log.Fields{
-				"topic":          m.Category(),
-				"round":          hdr.Round,
-				"step":           hdr.Step,
-				"expected round": round,
-			}).
-			Debugln("storing future event for later")
-		queue.PutEvent(hdr.Round, hdr.Step, m)
+	if cmp == header.After {
+		// Only store events up to 10 rounds into the future
+		if hdr.Round-round < 10 {
+			lg.
+				WithFields(log.Fields{
+					"topic":          m.Category(),
+					"round":          hdr.Round,
+					"step":           hdr.Step,
+					"expected round": round,
+				}).
+				Debugln("storing future event for later")
+			queue.PutEvent(hdr.Round, hdr.Step, m)
+		}
+
 		return false
 	}
 

--- a/pkg/core/consensus/selection/step.go
+++ b/pkg/core/consensus/selection/step.go
@@ -280,19 +280,21 @@ func shouldProcess(m message.Message, round uint64, step uint8, queue *consensus
 		return false
 	}
 
-	// Only store events up to 10 rounds into the future
 	// XXX: According to protocol specs, we should abandon consensus
 	// if we notice valid messages from far into the future.
-	if cmp == header.After && hdr.Round-round < 10 {
-		lg.
-			WithFields(log.Fields{
-				"topic":          m.Category(),
-				"round":          hdr.Round,
-				"step":           hdr.Step,
-				"expected round": round,
-			}).
-			Debugln("storing future event for later")
-		queue.PutEvent(hdr.Round, hdr.Step, m)
+	if cmp == header.After {
+		// Only store events up to 10 rounds into the future
+		if hdr.Round-round < 10 {
+			lg.
+				WithFields(log.Fields{
+					"topic":          m.Category(),
+					"round":          hdr.Round,
+					"step":           hdr.Step,
+					"expected round": round,
+				}).
+				Debugln("storing future event for later")
+			queue.PutEvent(hdr.Round, hdr.Step, m)
+		}
 
 		return false
 	}


### PR DESCRIPTION
fixes #1443 

NB: No `newblock verification error` noticed on devnet since the two fixes have been deployed