### PR TITLE
Propagate message metadata

### DIFF
--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -25,7 +25,7 @@ const (
 	MaxBlockTime = 360 // maximum block time in seconds
 
 	// KadcastInitialHeight sets the default initial height for Kadcast broadcast algorithm.
-	KadcastInitialHeight byte = 128 + 1
+	KadcastInitialHeight byte = 128
 
 	// The dusk-blockchain executable version.
 	NodeVersion = "0.6.0-rc"
@@ -63,6 +63,3 @@ const (
 	// GetCandidateReceivers is a redundancy factor on retrieving a missing candidate block.
 	GetCandidateReceivers = 7
 )
-
-// KadcastInitHeader is used as default initial kadcast message header.
-var KadcastInitHeader = []byte{KadcastInitialHeight}

--- a/pkg/core/candidate/requestor.go
+++ b/pkg/core/candidate/requestor.go
@@ -87,7 +87,7 @@ func (r *Requestor) publishGetCandidate(hash []byte) error {
 		return err
 	}
 
-	m := message.NewWithHeader(topics.GetCandidate, *buf, config.KadcastInitHeader)
+	m := message.New(topics.GetCandidate, *buf)
 
 	r.publisher.Publish(topics.Kadcast, m)
 	return nil
@@ -102,7 +102,7 @@ func (r *Requestor) sendGetCandidate(hash []byte) error {
 		return err
 	}
 
-	msg := message.NewWithHeader(topics.GetCandidate, buf, []byte{config.GetCandidateReceivers})
+	msg := message.NewWithMetadata(topics.GetCandidate, buf, &message.Metadata{NumNodes: config.GetCandidateReceivers})
 	r.publisher.Publish(topics.KadcastSendToMany, msg)
 	return nil
 }

--- a/pkg/core/chain/consensus.go
+++ b/pkg/core/chain/consensus.go
@@ -70,7 +70,7 @@ func (c *Chain) acceptConsensusResults(ctx context.Context, winnerChan chan cons
 				return
 			}
 
-			if err = c.acceptSuccessiveBlock(block, config.KadcastInitialHeight); err != nil {
+			if err = c.acceptSuccessiveBlock(block, nil); err != nil {
 				log.WithError(err).Error("block acceptance failed")
 				c.lock.Unlock()
 				return

--- a/pkg/core/chain/ledger.go
+++ b/pkg/core/chain/ledger.go
@@ -6,12 +6,15 @@
 
 package chain
 
-import "github.com/dusk-network/dusk-blockchain/pkg/core/data/block"
+import (
+	"github.com/dusk-network/dusk-blockchain/pkg/core/data/block"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
+)
 
 // Ledger is the Chain interface used in tests.
 type Ledger interface {
-	TryNextConsecutiveBlockInSync(blk block.Block, kadcastHeight byte) error
-	TryNextConsecutiveBlockOutSync(blk block.Block, kadcastHeight byte) error
+	TryNextConsecutiveBlockInSync(blk block.Block, metadata *message.Metadata) error
+	TryNextConsecutiveBlockOutSync(blk block.Block, metadata *message.Metadata) error
 	TryNextConsecutiveBlockIsValid(blk block.Block) error
 
 	// RestartConsensus Stop and Start Consensus.

--- a/pkg/core/chain/synchronizer_test.go
+++ b/pkg/core/chain/synchronizer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dusk-network/dusk-blockchain/pkg/core/database"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/database/lite"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/tests/helper"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
 	assert "github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ func TestSuccessiveBlocks(t *testing.T) {
 
 	// tipHeight will be 0, so make the successive block
 	blk := helper.RandomBlock(1, 1)
-	res, err := s.processBlock("", 0, *blk, 0)
+	res, err := s.processBlock("", 0, *blk, nil)
 	assert.NoError(err)
 	assert.Nil(res)
 
@@ -40,7 +41,7 @@ func TestFutureBlocks(t *testing.T) {
 
 	height := uint64(10)
 	blk := helper.RandomBlock(height, 1)
-	resp, err := s.processBlock("", 0, *blk, 0)
+	resp, err := s.processBlock("", 0, *blk, nil)
 	assert.NoError(err)
 
 	// Response should be of the GetBlocks topic
@@ -75,12 +76,12 @@ func (m *mockChain) CurrentHeight() uint64 {
 	return m.tipHeight
 }
 
-func (m *mockChain) TryNextConsecutiveBlockInSync(blk block.Block, _ byte) error {
+func (m *mockChain) TryNextConsecutiveBlockInSync(blk block.Block, _ *message.Metadata) error {
 	m.catchBlockChan <- consensus.Results{Blk: blk, Err: nil}
 	return nil
 }
 
-func (m *mockChain) TryNextConsecutiveBlockOutSync(_ block.Block, _ byte) error {
+func (m *mockChain) TryNextConsecutiveBlockOutSync(_ block.Block, _ *message.Metadata) error {
 	return nil
 }
 

--- a/pkg/core/consensus/agreement/agreement_in_test.go
+++ b/pkg/core/consensus/agreement/agreement_in_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/dusk-network/bls12_381-sign/go/cgo/bls"
-	"github.com/dusk-network/dusk-blockchain/pkg/config"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/header"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
@@ -90,7 +89,7 @@ func TestAccumulatorProcessingAggregation(t *testing.T) {
 	// Verify certificate
 	comm = handler.Committee(hdr.Round, hdr.Step)
 
-	msg := message.NewWithHeader(topics.AggrAgreement, aggro, config.KadcastInitHeader)
+	msg := message.New(topics.AggrAgreement, aggro)
 	buf, err := message.Marshal(msg)
 	assert.Nil(t, err, "failed to marshal aggragreement")
 

--- a/pkg/core/consensus/agreement/step.go
+++ b/pkg/core/consensus/agreement/step.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/dusk-network/bls12_381-sign/go/cgo/bls"
-	"github.com/dusk-network/dusk-blockchain/pkg/config"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/candidate"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/consensus/header"
@@ -244,7 +243,7 @@ func collectAgreement(h *handler, accumulator *Accumulator, ev message.Message, 
 		return
 	}
 
-	m := message.NewWithHeader(topics.Agreement, a.Copy().(message.Agreement), ev.Header())
+	m := message.NewWithMetadata(topics.Agreement, a.Copy().(message.Agreement), ev.Metadata())
 
 	// Once the event is verified, we can republish it.
 	if err := e.Republish(m); err != nil {
@@ -288,9 +287,9 @@ func (s *Loop) processCollectedVotes(ctx context.Context, handler *handler, evs 
 	bits := comm.Bits(*pubs)
 	agAgreement := message.NewAggrAgreement(evs[0], bits, sig)
 
-	m := message.NewWithHeader(topics.AggrAgreement, agAgreement, config.KadcastInitHeader)
+	m := message.New(topics.AggrAgreement, agAgreement)
 	if err := s.Emitter.Republish(m); err != nil {
-		lg.WithError(err).Error("could not republish aggregated agreement event")
+		lg.WithError(err).Error("could broadcast aggregated agreement event")
 	} else {
 		lg.
 			WithField("round", r.Round).
@@ -380,7 +379,7 @@ func (s *Loop) processAggrAgreement(ctx context.Context, h *handler, msg message
 	}
 
 	// Broadcast
-	m := message.NewWithHeader(topics.AggrAgreement, aggro.Copy(), config.KadcastInitHeader)
+	m := message.NewWithMetadata(topics.AggrAgreement, aggro.Copy(), msg.Metadata())
 	if err = e.Republish(m); err != nil {
 		lg.WithError(err).Errorln("could not republish aggragreement event")
 		return nil, err

--- a/pkg/core/consensus/comms.go
+++ b/pkg/core/consensus/comms.go
@@ -152,7 +152,7 @@ func (e *Emitter) Kadcast(msg message.Message) error {
 		return err
 	}
 
-	serialized := message.NewWithHeader(msg.Category(), buf, msg.Header())
+	serialized := message.NewWithMetadata(msg.Category(), buf, msg.Metadata())
 	e.EventBus.Publish(topics.Kadcast, serialized)
 	return nil
 }

--- a/pkg/core/consensus/reduction/reduction.go
+++ b/pkg/core/consensus/reduction/reduction.go
@@ -152,7 +152,7 @@ func (r *Reduction) SendReduction(ctx context.Context, round uint64, step uint8,
 	red := message.NewReduction(hdr)
 	red.SignedHash = sig
 
-	m := message.NewWithHeader(topics.Reduction, *red, config.KadcastInitHeader)
+	m := message.New(topics.Reduction, *red)
 	return m, voteHash, nil
 }
 

--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -214,7 +214,12 @@ func (m *Mempool) ProcessTx(srcPeerID string, msg message.Message) ([]bytes.Buff
 		return nil, errors.New("mempool is full, dropping transaction")
 	}
 
-	var h byte
+	// Initializing `h=0` or `h=KadcastInitialHeight` will not work.
+	// This because `h` will be decremented by the kadcast writer as per
+	// it's interpreted as "the kadcast height at which it's been received"
+	// Hence, `h=0` will not be broadcasted at all and
+	// `h=KadcastInitialHeight` will miss the broadcast to the first bucket
+	var h byte = math.MaxUint8
 	if msg.Metadata() != nil {
 		h = msg.Metadata().KadcastHeight
 	}
@@ -495,10 +500,6 @@ func (m Mempool) processGetMempoolTxsBySizeRequest(r rpcbus.Request) (interface{
 
 // kadcastTx (re)propagates transaction in kadcast network.
 func (m *Mempool) kadcastTx(t TxDesc) error {
-	if t.kadHeight > config.KadcastInitialHeight {
-		return errors.New("invalid kadcast height")
-	}
-
 	/// repropagate
 	buf := new(bytes.Buffer)
 	if err := transactions.Marshal(buf, t.tx); err != nil {

--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -214,8 +215,8 @@ func (m *Mempool) ProcessTx(srcPeerID string, msg message.Message) ([]bytes.Buff
 	}
 
 	var h byte
-	if len(msg.Header()) > 0 {
-		h = msg.Header()[0]
+	if msg.Metadata() != nil {
+		h = msg.Metadata().KadcastHeight
 	}
 
 	t := TxDesc{
@@ -508,7 +509,8 @@ func (m *Mempool) kadcastTx(t TxDesc) error {
 		return err
 	}
 
-	msg := message.NewWithHeader(topics.Tx, *buf, []byte{t.kadHeight})
+	metadata := message.Metadata{KadcastHeight: t.kadHeight}
+	msg := message.NewWithMetadata(topics.Tx, *buf, &metadata)
 
 	m.eventBus.Publish(topics.Kadcast, msg)
 	return nil
@@ -536,7 +538,8 @@ func (m *Mempool) RequestUpdates() {
 		panic(err)
 	}
 
-	msg := message.NewWithHeader(topics.MemPool, buf, []byte{numNodes})
+	metadata := message.Metadata{NumNodes: numNodes}
+	msg := message.NewWithMetadata(topics.MemPool, buf, &metadata)
 	m.eventBus.Publish(topics.KadcastSendToMany, msg)
 }
 

--- a/pkg/p2p/kadcast/writer/sendone.go
+++ b/pkg/p2p/kadcast/writer/sendone.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/protocol"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
 	"github.com/dusk-network/dusk-blockchain/pkg/util/container/ring"
@@ -45,18 +46,18 @@ func (w *SendToOne) Subscribe() {
 }
 
 // Write implements. ring.Writer.
-func (w *SendToOne) Write(data, header []byte, priority byte) (int, error) {
-	if err := w.sendToOne(data, header, priority); err != nil {
+func (w *SendToOne) Write(data []byte, metadata *message.Metadata, priority byte) (int, error) {
+	if err := w.sendToOne(data, metadata, priority); err != nil {
 		log.WithError(err).Warn("write failed")
 	}
 
 	return 0, nil
 }
 
-func (w *SendToOne) sendToOne(data, header []byte, _ byte) error {
-	if len(header) == 0 {
-		return errors.New("empty message header")
+func (w *SendToOne) sendToOne(data []byte, metadata *message.Metadata, _ byte) error {
+	if metadata == nil {
+		return errors.New("empty message metadata")
 	}
 
-	return w.Send(data, string(header))
+	return w.Send(data, metadata.Source)
 }

--- a/pkg/p2p/peer/peer.go
+++ b/pkg/p2p/peer/peer.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/checksum"
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/protocol"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/topics"
 	"github.com/dusk-network/dusk-blockchain/pkg/util/container/ring"
@@ -62,7 +63,7 @@ type GossipConnector struct {
 	*Connection
 }
 
-func (g *GossipConnector) Write(b, header []byte, priority byte) (int, error) {
+func (g *GossipConnector) Write(b []byte, _ *message.Metadata, priority byte) (int, error) {
 	if !canRoute(g.services, topics.Topic(b[0])) {
 		return 0, nil
 	}

--- a/pkg/p2p/peer/processor.go
+++ b/pkg/p2p/peer/processor.go
@@ -49,7 +49,7 @@ func (m *MessageProcessor) Register(topic topics.Topic, fn ProcessorFunc) {
 
 // Collect a message from the network. The message is unmarshaled and passed down
 // to the processing function.
-func (m *MessageProcessor) Collect(srcPeerID string, packet []byte, respRingBuf *ring.Buffer, services protocol.ServiceFlag, header []byte) ([]bytes.Buffer, error) {
+func (m *MessageProcessor) Collect(srcPeerID string, packet []byte, respRingBuf *ring.Buffer, services protocol.ServiceFlag, metadata *message.Metadata) ([]bytes.Buffer, error) {
 	if len(packet) == 0 {
 		return nil, errors.New("empty packet provided")
 	}
@@ -58,7 +58,7 @@ func (m *MessageProcessor) Collect(srcPeerID string, packet []byte, respRingBuf 
 	b := bytes.NewBuffer(packet)
 	topic := topics.Topic(b.Bytes()[0])
 
-	msg, err := message.Unmarshal(b, header)
+	msg, err := message.Unmarshal(b, metadata)
 	if err != nil {
 		return nil, fmt.Errorf("error while unmarshaling: %s - topic: %s", err, topic)
 	}

--- a/pkg/p2p/wire/message/metadata.go
+++ b/pkg/p2p/wire/message/metadata.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this
+// file, you can obtain one at https://opensource.org/licenses/MIT.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+package message
+
+// Metadata is a struct containing messages metadata.
+type Metadata struct {
+	KadcastHeight byte
+	Source        string
+	NumNodes      byte
+}
+
+func (m simple) Metadata() *Metadata {
+	return m.metadata
+}

--- a/pkg/p2p/wire/message/transactions_test.go
+++ b/pkg/p2p/wire/message/transactions_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/dusk-network/dusk-blockchain/pkg/config"
 	"github.com/dusk-network/dusk-blockchain/pkg/core/data/ipc/transactions"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/checksum"
 	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
@@ -63,7 +62,7 @@ func TestWireTransaction(t *testing.T) {
 
 	buffer := bytes.NewBuffer(m)
 
-	message, err := message.Unmarshal(buffer, config.KadcastInitHeader)
+	message, err := message.Unmarshal(buffer, nil)
 	if err != nil {
 		t.Fatalf("Unable to unmarshal: %v", err)
 	}

--- a/pkg/util/container/ring/buffer.go
+++ b/pkg/util/container/ring/buffer.go
@@ -10,12 +10,14 @@ import (
 	"bytes"
 	"sync"
 	"sync/atomic"
+
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 )
 
 // Elem single data unit of a ring buffer.
 type Elem struct {
 	Data     []byte
-	Header   []byte
+	Metadata *message.Metadata
 	Priority byte
 }
 

--- a/pkg/util/container/ring/consumer.go
+++ b/pkg/util/container/ring/consumer.go
@@ -8,11 +8,13 @@ package ring
 
 import (
 	"sort"
+
+	"github.com/dusk-network/dusk-blockchain/pkg/p2p/wire/message"
 )
 
 // Writer defines a Writer interface compatible with ring.Elem.
 type Writer interface {
-	Write(data, header []byte, priority byte) (int, error)
+	Write(data []byte, metadata *message.Metadata, priority byte) (int, error)
 	Close() error
 }
 

--- a/pkg/util/nativeutils/eventbus/eventbus_test.go
+++ b/pkg/util/nativeutils/eventbus/eventbus_test.go
@@ -185,7 +185,7 @@ func TestExitChan(t *testing.T) {
 
 type mockWriteCloser struct{}
 
-func (m *mockWriteCloser) Write(data, header []byte, priority byte) (int, error) {
+func (m *mockWriteCloser) Write(data []byte, _ *message.Metadata, priority byte) (int, error) {
 	return 0, errors.New("failed")
 }
 

--- a/pkg/util/nativeutils/eventbus/listener.go
+++ b/pkg/util/nativeutils/eventbus/listener.go
@@ -123,7 +123,7 @@ func (s *StreamListener) Notify(m message.Message) error {
 
 		e := ring.Elem{
 			Data:     buf.Bytes(),
-			Header:   m.Header(),
+			Metadata: m.Metadata(),
 			Priority: 0,
 		}
 
@@ -153,7 +153,7 @@ func (s *StreamListener) Close() {
 // Consume an item by writing it to the specified WriteCloser. This is used in the StreamListener creation.
 func Consume(elems []ring.Elem, w ring.Writer) bool {
 	for _, e := range elems {
-		if _, err := w.Write(e.Data, e.Header, e.Priority); err != nil {
+		if _, err := w.Write(e.Data, e.Metadata, e.Priority); err != nil {
 			logEB.WithField("queue", "ringbuffer").WithError(err).Warnln("error in writing to WriteCloser")
 			return false
 		}

--- a/pkg/util/nativeutils/eventbus/mock.go
+++ b/pkg/util/nativeutils/eventbus/mock.go
@@ -149,7 +149,7 @@ func NewSimpleStreamer() *SimpleStreamer {
 
 // Write receives the packets from the ringbuffer and writes it on the internal
 // pipe immediately.
-func (ms *SimpleStreamer) Write(data, header []byte, priority byte) (n int, err error) {
+func (ms *SimpleStreamer) Write(data []byte, _ *message.Metadata, priority byte) (n int, err error) {
 	b := bytes.NewBuffer(data)
 	if e := ms.gossip.Process(b); e != nil {
 		return 0, e


### PR DESCRIPTION
- Replace the current `message.Header` bytes with a structured `message.Metadata`
- Remove redundant usages of `config.KadcastInitHeader`

Resolves #1452