### PR TITLE
Propagate blockchain tip on kadcast client launch

### DIFF
--- a/cmd/dusk/server.go
+++ b/cmd/dusk/server.go
@@ -184,6 +184,11 @@ func Setup() *Server {
 	kcfg := cfg.Get().Kadcast
 	if kcfg.Enabled {
 		srv.launchKadcastPeer(parentCtx, processor, gossip)
+
+		// Wait for the kadcast client setup
+		time.Sleep(3 * time.Second)
+
+		c.ResendBlockhainTip(300)
 	}
 
 	// Schedule mempool updates requesting a few seconds after all components

--- a/pkg/core/chain/chain.go
+++ b/pkg/core/chain/chain.go
@@ -230,6 +230,11 @@ func (c *Chain) syncWithRusk() error {
 			break
 		}
 
+		if err := c.kadcastBlock(*blk, nil); err != nil {
+			log.WithError(err).Error("block propagation failed")
+			// return err
+		}
+
 		// Re-accepting all blocks that have not been persisted in Rusk.
 		// This will re-execute accept/finalize accordingly and update chain tip.
 		if err := c.acceptBlock(*blk, false); err != nil {

--- a/pkg/core/chain/chain.go
+++ b/pkg/core/chain/chain.go
@@ -230,10 +230,6 @@ func (c *Chain) syncWithRusk() error {
 			break
 		}
 
-		if err := c.sendBlockToMany(*blk, 300); err != nil {
-			log.WithError(err).Error("block send-to-many failed")
-		}
-
 		// Re-accepting all blocks that have not been persisted in Rusk.
 		// This will re-execute accept/finalize accordingly and update chain tip.
 		if err := c.acceptBlock(*blk, false); err != nil {
@@ -242,6 +238,12 @@ func (c *Chain) syncWithRusk() error {
 	}
 
 	return nil
+}
+
+func (c *Chain) ResendBlockhainTip(numNodes uint32) {
+	if err := c.sendBlockToMany(*c.tip, numNodes); err != nil {
+		log.WithError(err).Error("block send-to-many failed")
+	}
 }
 
 // ProcessBlockFromNetwork will handle blocks incoming from the network.

--- a/pkg/core/chain/chain.go
+++ b/pkg/core/chain/chain.go
@@ -230,7 +230,7 @@ func (c *Chain) syncWithRusk() error {
 			break
 		}
 
-		if err := c.sendBlockToMany(*blk); err != nil {
+		if err := c.sendBlockToMany(*blk, 300); err != nil {
 			log.WithError(err).Error("block send-to-many failed")
 		}
 
@@ -787,7 +787,7 @@ func (c *Chain) kadcastBlock(blk block.Block, metadata *message.Metadata) error 
 	return nil
 }
 
-func (c *Chain) sendBlockToMany(blk block.Block) error {
+func (c *Chain) sendBlockToMany(blk block.Block, numNodes uint32) error {
 	buf := new(bytes.Buffer)
 	if err := message.MarshalBlock(buf, &blk); err != nil {
 		return err
@@ -797,7 +797,7 @@ func (c *Chain) sendBlockToMany(blk block.Block) error {
 		return err
 	}
 
-	c.eventBus.Publish(topics.KadcastSendToMany, message.NewWithMetadata(topics.Block, *buf, &message.Metadata{NumNodes: 255}))
+	c.eventBus.Publish(topics.KadcastSendToMany, message.NewWithMetadata(topics.Block, *buf, &message.Metadata{NumNodes: numNodes}))
 	return nil
 }
 

--- a/pkg/core/chain/chain_rc_test.go
+++ b/pkg/core/chain/chain_rc_test.go
@@ -4,6 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+//go:build race
 // +build race
 
 package chain

--- a/pkg/core/chain/consensus.go
+++ b/pkg/core/chain/consensus.go
@@ -23,6 +23,10 @@ func (c *Chain) RestartConsensus() error {
 	return c.startConsensus()
 }
 
+func (c *Chain) GetTip() uint64 {
+	return c.tip.Header.Height
+}
+
 // startConsensus will start the consensus loop. It can be halted at any point by
 // sending a signal through the `stopConsensus` channel (`StopConsensus`
 // as exposed by the `Ledger` interface).

--- a/pkg/core/mempool/mempool.go
+++ b/pkg/core/mempool/mempool.go
@@ -539,7 +539,7 @@ func (m *Mempool) RequestUpdates() {
 		panic(err)
 	}
 
-	metadata := message.Metadata{NumNodes: numNodes}
+	metadata := message.Metadata{NumNodes: uint32(numNodes)}
 	msg := message.NewWithMetadata(topics.MemPool, buf, &metadata)
 	m.eventBus.Publish(topics.KadcastSendToMany, msg)
 }

--- a/pkg/p2p/kadcast/writer/sendmany.go
+++ b/pkg/p2p/kadcast/writer/sendmany.go
@@ -62,7 +62,7 @@ func (w *SendToMany) sendToMany(data []byte, metadata *message.Metadata, _ byte)
 	}
 
 	// get N active nodes
-	req := &rusk.AliveNodesRequest{MaxNodes: uint32(metadata.NumNodes)}
+	req := &rusk.AliveNodesRequest{MaxNodes: metadata.NumNodes}
 
 	resp, err := w.client.AliveNodes(w.ctx, req)
 	if err != nil {

--- a/pkg/p2p/wire/message/metadata.go
+++ b/pkg/p2p/wire/message/metadata.go
@@ -10,7 +10,7 @@ package message
 type Metadata struct {
 	KadcastHeight byte
 	Source        string
-	NumNodes      byte
+	NumNodes      uint32
 }
 
 func (m simple) Metadata() *Metadata {


### PR DESCRIPTION
This is a draft PR that is an attempt to re-enable community provisioners to re-join consensus. If this happens, additional votes will be broadcast allowing Testnet to reach quorum and finalize a consecutive block.