### PR TITLE
Release `0.6.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2022-12-21 
+
 ### Added
 - Add `raw` field to GQL transaction object [#1481]
 - Add `blocksrange` filter to GQL transaction lookup [#1468]
@@ -151,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/dusk-blockchain/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/dusk-network/dusk-blockchain/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/dusk-network/dusk-blockchain/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/dusk-network/dusk-blockchain/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/dusk-network/dusk-blockchain/compare/v0.4.4...v0.5.0

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -28,7 +28,7 @@ const (
 	KadcastInitialHeight byte = 128
 
 	// The dusk-blockchain executable version.
-	NodeVersion = "0.6.1"
+	NodeVersion = "0.6.2-rc.0"
 
 	// Consensus-related settings
 	// Protocol-based consensus step time.

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -28,7 +28,7 @@ const (
 	KadcastInitialHeight byte = 128
 
 	// The dusk-blockchain executable version.
-	NodeVersion = "0.6.0"
+	NodeVersion = "0.6.1"
 
 	// Consensus-related settings
 	// Protocol-based consensus step time.


### PR DESCRIPTION
### Added
- Add `raw` field to GQL transaction object [#1481]
- Add `blocksrange` filter to GQL transaction lookup [#1468]

### Removed
- Remove hardcoded genesis checks [#1464]
- Remove provisioners list updates at every block [#1479]
