### PR TITLE
Add `Iteration` to block header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `Iteration` to block header [#1500]
+
+### Removed
+- Remove `step` from block header certificate [#1500]
+
 ## [0.6.1] - 2022-12-21 
 
 ### Added
@@ -91,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Issues -->
 
+[#1500]: https://github.com/dusk-network/dusk-blockchain/issues/1500
 [#1481]: https://github.com/dusk-network/dusk-blockchain/issues/1481
 [#1479]: https://github.com/dusk-network/dusk-blockchain/issues/1479
 [#1464]: https://github.com/dusk-network/dusk-blockchain/issues/1464

--- a/pkg/core/chain/chain_test.go
+++ b/pkg/core/chain/chain_test.go
@@ -108,7 +108,7 @@ func TestAcceptBlock(t *testing.T) {
 	// Make a certificate with a different step, to do a proper equality
 	// check later
 	cert := block.EmptyCertificate()
-	cert.Step = 5
+	blk.Header.Iteration = 2
 	blk.Header.Certificate = cert
 
 	assert.NoError(c.acceptBlock(*blk, true), true)
@@ -180,7 +180,7 @@ func TestFallbackProcedure(t *testing.T) {
 	blk1 := helper.RandomBlock(1, 3)
 
 	cert1 := block.EmptyCertificate()
-	cert1.Step = 6
+	blk1.Header.Iteration = 2
 	blk1.Header.Certificate = cert1
 
 	chain.ProcessBlockFromNetwork("", message.New(topics.Block, *blk1))
@@ -195,7 +195,7 @@ func TestFallbackProcedure(t *testing.T) {
 	blk2 := helper.RandomBlock(1, 3)
 
 	cert2 := block.EmptyCertificate()
-	cert2.Step = 3 // (first iteration certificate)
+	blk1.Header.Iteration = 1
 	blk2.Header.Certificate = cert2
 
 	chain.ProcessBlockFromNetwork("", message.New(topics.Block, *blk2))

--- a/pkg/core/chain/fallback.go
+++ b/pkg/core/chain/fallback.go
@@ -22,7 +22,7 @@ import (
 // allowFallback performs major verification to allow or disallow a fallback procedure.
 func (c *Chain) allowFallback(b block.Block, l *logrus.Entry) error {
 	// Prioritize the lowest iteration
-	if b.Header.Certificate.Step > c.tip.Header.Certificate.Step {
+	if b.Header.Iteration > c.tip.Header.Iteration {
 		// We already know a winning block from lower consensus iteration.
 		return errors.New("lower cetificate step")
 	}
@@ -39,7 +39,7 @@ func (c *Chain) allowFallback(b block.Block, l *logrus.Entry) error {
 		return err
 	}
 
-	if b.Header.Certificate.Step == c.tip.Header.Certificate.Step {
+	if b.Header.Iteration == c.tip.Header.Iteration {
 		return errors.New("more the one winning block for the same iteration")
 	}
 
@@ -53,8 +53,8 @@ func (c *Chain) tryFallback(b block.Block) error {
 		err       error
 
 		llog = log.WithField("curr_h", th).
-			WithField("curr_step", c.tip.Header.Certificate.Step).
-			WithField("recv_blk_step", b.Header.Certificate.Step).
+			WithField("curr_iteration", c.tip.Header.Iteration).
+			WithField("recv_blk_iteration", b.Header.Iteration).
 			WithField("event", "fallback")
 	)
 

--- a/pkg/core/consensus/agreement/checkcert.go
+++ b/pkg/core/consensus/agreement/checkcert.go
@@ -28,8 +28,8 @@ func CheckBlockCertificate(provisioners user.Provisioners, blk block.Block, seed
 
 	// First, lets get the actual reduction steps
 	// These would be the two steps preceding the one on the certificate
-	stepOne := blk.Header.Certificate.Step - 1
-	stepTwo := blk.Header.Certificate.Step
+	stepOne := (blk.Header.Iteration-1)*3 + 2
+	stepTwo := (blk.Header.Iteration-1)*3 + 3
 
 	stepOneBatchedSig := blk.Header.Certificate.StepOneBatchedSig
 	stepTwoBatchedSig := blk.Header.Certificate.StepTwoBatchedSig

--- a/pkg/core/consensus/blockgenerator/candidate/genesis.go
+++ b/pkg/core/consensus/blockgenerator/candidate/genesis.go
@@ -34,7 +34,7 @@ func GenerateGenesisBlock(e *consensus.Emitter) (string, error) {
 	// TODO: do we need to generate correct proof and score
 	seed, _ := crypto.RandEntropy(33)
 
-	b, err := g.GenerateBlock(context.Background(), 0, seed, make([]byte, 32), time.Now().Unix())
+	b, err := g.GenerateBlock(context.Background(), 0, seed, make([]byte, 32), time.Now().Unix(), 0)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/core/consensus/blockgenerator/candidate/mock.go
+++ b/pkg/core/consensus/blockgenerator/candidate/mock.go
@@ -25,7 +25,7 @@ func (m *mock) MockCandidate(hdr header.Header, previousBlock []byte) block.Bloc
 
 	seed, _ := crypto.RandEntropy(32)
 
-	b, err := m.GenerateBlock(context.Background(), hdr.Round, seed, previousBlock, 0)
+	b, err := m.GenerateBlock(context.Background(), hdr.Round, seed, previousBlock, 0, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/core/data/block/certificate.go
+++ b/pkg/core/data/block/certificate.go
@@ -14,7 +14,6 @@ import (
 type Certificate struct {
 	StepOneBatchedSig []byte `json:"step-one-batched-sig"` // Batched BLS signature of the block reduction phase (33 bytes)
 	StepTwoBatchedSig []byte `json:"step-two-batched-sig"`
-	Step              uint8  `json:"step"`               // Step the agreement terminated at (1 byte)
 	StepOneCommittee  uint64 `json:"step-one-committee"` // Binary representation of the committee members who voted in favor of this block (8 bytes)
 	StepTwoCommittee  uint64 `json:"step-two-committee"`
 }
@@ -32,7 +31,6 @@ func (c *Certificate) Copy() *Certificate {
 		copy(cert.StepTwoBatchedSig, c.StepTwoBatchedSig)
 	}
 
-	cert.Step = c.Step
 	cert.StepOneCommittee = c.StepOneCommittee
 	cert.StepTwoCommittee = c.StepTwoCommittee
 
@@ -44,7 +42,6 @@ func EmptyCertificate() *Certificate {
 	return &Certificate{
 		StepOneBatchedSig: make([]byte, 33),
 		StepTwoBatchedSig: make([]byte, 33),
-		Step:              0,
 		StepOneCommittee:  0,
 		StepTwoCommittee:  0,
 	}
@@ -61,10 +58,6 @@ func (c *Certificate) Equals(other *Certificate) bool {
 	}
 
 	if !bytes.Equal(c.StepTwoBatchedSig, other.StepTwoBatchedSig) {
-		return false
-	}
-
-	if c.Step != other.Step {
 		return false
 	}
 

--- a/pkg/core/data/block/header.go
+++ b/pkg/core/data/block/header.go
@@ -29,6 +29,7 @@ type Header struct {
 	Height    uint64 `json:"height"`    // Block height
 	Timestamp int64  `json:"timestamp"` // Block timestamp
 	GasLimit  uint64 `json:"gaslimit"`  // Block gas limit
+	Iteration uint8  `json:"iteration"` // Iteration at which block is produced
 
 	PrevBlockHash      []byte `json:"prev-hash"`  // Hash of previous block (32 bytes)
 	Seed               []byte `json:"seed"`       // Marshaled BLS signature or hash of the previous block seed (32 bytes)
@@ -62,6 +63,7 @@ func (b *Header) Copy() *Header {
 		Height:      b.Height,
 		Timestamp:   b.Timestamp,
 		GasLimit:    b.GasLimit,
+		Iteration:   b.Iteration,
 	}
 
 	h.PrevBlockHash = make([]byte, len(b.PrevBlockHash))
@@ -131,6 +133,10 @@ func (b *Header) Equals(other *Header) bool {
 		return false
 	}
 
+	if b.Iteration != other.Iteration {
+		return false
+	}
+
 	return true
 }
 
@@ -164,6 +170,10 @@ func marshalHashable(b *bytes.Buffer, h *Header) error {
 	}
 
 	if err := binary.Write(b, binary.LittleEndian, h.GasLimit); err != nil {
+		return err
+	}
+
+	if err := b.WriteByte(h.Iteration); err != nil {
 		return err
 	}
 

--- a/pkg/core/verifiers/block.go
+++ b/pkg/core/verifiers/block.go
@@ -34,8 +34,8 @@ func CheckBlockCertificate(provisioners user.Provisioners, blk block.Block, seed
 
 	// First, lets get the actual reduction steps
 	// These would be the two steps preceding the one on the certificate
-	stepOne := blk.Header.Certificate.Step - 1
-	stepTwo := blk.Header.Certificate.Step
+	stepOne := (blk.Header.Iteration-1)*3 + 2
+	stepTwo := (blk.Header.Iteration-1)*3 + 2
 
 	stepOneBatchedSig := blk.Header.Certificate.StepOneBatchedSig
 	stepTwoBatchedSig := blk.Header.Certificate.StepTwoBatchedSig

--- a/pkg/gql/query/blocks.go
+++ b/pkg/gql/query/blocks.go
@@ -291,7 +291,7 @@ func resolveStep(p graphql.ResolveParams) (interface{}, error) {
 				return err
 			}
 
-			step = int(h.Certificate.Step)
+			step = int(h.Iteration * 3)
 			return nil
 		})
 

--- a/pkg/p2p/wire/message/agreement.go
+++ b/pkg/p2p/wire/message/agreement.go
@@ -220,7 +220,6 @@ func (a Agreement) GenerateCertificate() *block.Certificate {
 	return &block.Certificate{
 		StepOneBatchedSig: a.VotesPerStep[0].Signature,
 		StepTwoBatchedSig: a.VotesPerStep[1].Signature,
-		Step:              a.State().Step,
 		StepOneCommittee:  a.VotesPerStep[0].BitSet,
 		StepTwoCommittee:  a.VotesPerStep[1].BitSet,
 	}

--- a/pkg/p2p/wire/message/block.go
+++ b/pkg/p2p/wire/message/block.go
@@ -113,6 +113,10 @@ func MarshalHashable(r *bytes.Buffer, h *block.Header) error {
 		return err
 	}
 
+	if err := encoding.WriteUint8(r, h.Iteration); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -171,6 +175,10 @@ func UnmarshalHeader(r *bytes.Buffer, h *block.Header) error {
 	}
 
 	if err := encoding.ReadUint64LE(r, &h.GasLimit); err != nil {
+		return err
+	}
+
+	if err := encoding.ReadUint8(r, &h.Iteration); err != nil {
 		return err
 	}
 

--- a/pkg/p2p/wire/message/block.go
+++ b/pkg/p2p/wire/message/block.go
@@ -204,10 +204,6 @@ func MarshalCertificate(r *bytes.Buffer, c *block.Certificate) error {
 		return err
 	}
 
-	if err := encoding.WriteUint8(r, c.Step); err != nil {
-		return err
-	}
-
 	if err := encoding.WriteUint64LE(r, c.StepOneCommittee); err != nil {
 		return err
 	}
@@ -228,10 +224,6 @@ func UnmarshalCertificate(r *bytes.Buffer, c *block.Certificate) error {
 
 	c.StepTwoBatchedSig = make([]byte, 0)
 	if err := encoding.ReadVarBytes(r, &c.StepTwoBatchedSig); err != nil {
-		return err
-	}
-
-	if err := encoding.ReadUint8(r, &c.Step); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This add `iteration` to the block header, including it into the hashed fields used to calculate the block hash

In addition, this PR remove `step` from block header certificate (since it's a duplicated info)

Resolves #1500