### PR TITLE
Restore compatibility with rusk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Iteration` to block header [#1500]
 - Add `TxRoot` to block header [#1499]
 
+### Changed
+- Change rusk-version compatibility to `0.6.0` [#1514]
+
 ### Removed
 - Remove `step` from block header certificate [#1500]
 
@@ -98,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Issues -->
 
+[#1514]: https://github.com/dusk-network/dusk-blockchain/issues/1514
 [#1500]: https://github.com/dusk-network/dusk-blockchain/issues/1500
 [#1499]: https://github.com/dusk-network/dusk-blockchain/issues/1499
 [#1481]: https://github.com/dusk-network/dusk-blockchain/issues/1481

--- a/harness/engine/network.go
+++ b/harness/engine/network.go
@@ -387,8 +387,8 @@ func (n *Network) start(nodeDir string, name string, arg ...string) error {
 	if err != nil {
 		log.Panic(err)
 	}
-	targetCrs := filepath.Join(extProfilePath, ".rusk", "dev.crs")
-	newCrs := filepath.Join(nodeDir, ".rusk", "dev.crs")
+	targetCrs := filepath.Join(extProfilePath, ".rusk", "dev-piecrust.crs")
+	newCrs := filepath.Join(nodeDir, ".rusk", "dev-piecrust.crs")
 	os.Symlink(targetCrs, newCrs)
 
 	// LINK THE ORIGINAL keys

--- a/pkg/config/consts.go
+++ b/pkg/config/consts.go
@@ -52,7 +52,7 @@ const (
 	ConsensusSelectionMaxCommitteeSize = 1
 
 	// RuskVersion is the version of the supported rusk binary.
-	RuskVersion = "0.5.0"
+	RuskVersion = "0.6.0"
 
 	// GetCandidateReceivers is a redundancy factor on retrieving a missing candidate block.
 	GetCandidateReceivers = 7


### PR DESCRIPTION
- Change `rusk-version` to `0.6.0`
- Fix test-harness to use piecrust crs

Resolves #1514